### PR TITLE
Adding support for "One by Wacom CTL472" and "One by Wacom CTL672". I…

### DIFF
--- a/2.6.30/wacom_wac.c
+++ b/2.6.30/wacom_wac.c
@@ -2570,6 +2570,10 @@ static const struct wacom_features wacom_features_0x35A =
 static const struct wacom_features wacom_features_0x368 =
 	{ "Wacom DTH-1152 Touch", WACOM_PKGLEN_27QHDT, .type = DTH1152T,
 	  .oVid = USB_VENDOR_ID_WACOM, .oPid = 0x35a }; /* Touch */
+static const struct wacom_features wacom_features_0x37A =
+	{ "One by Wacom CTL472",    WACOM_PKGLEN_BBPEN,    14720,  9225, 2047, 63, BAMBOO_PT };
+static const struct wacom_features wacom_features_0x37B =
+	{ "One by Wacom CTL672",    WACOM_PKGLEN_BBPEN,    21648, 13530, 2047, 63, BAMBOO_PT };
 
 #define USB_DEVICE_WACOM(prod)					\
 	USB_DEVICE(USB_VENDOR_ID_WACOM, prod),			\
@@ -2736,6 +2740,8 @@ const struct usb_device_id wacom_ids[] = {
 	{ USB_DEVICE_WACOM(0x35A) },
 	{ USB_DEVICE_WACOM(0x368) },
 	{ USB_DEVICE_LENOVO(0x6004) },
+	{ USB_DEVICE_WACOM(0x37A) },
+	{ USB_DEVICE_WACOM(0x37B) },
 	{ }
 };
 MODULE_DEVICE_TABLE(usb, wacom_ids);

--- a/2.6.38/wacom_wac.c
+++ b/2.6.38/wacom_wac.c
@@ -3257,6 +3257,12 @@ static const struct wacom_features wacom_features_0x368 =
 	{ "Wacom DTH-1152 Touch", WACOM_PKGLEN_27QHDT,
 	  .type = DTH1152T, .touch_max = 10, .oVid = USB_VENDOR_ID_WACOM,
 	  .oPid = 0x35A }; /* Touch */
+static const struct wacom_features wacom_features_0x37A =
+	{ "One by Wacom CTL472",    WACOM_PKGLEN_BBPEN,    14720,  9225, 2047,
+	  63, BAMBOO_PT, WACOM_INTUOS_RES, WACOM_INTUOS_RES };
+static const struct wacom_features wacom_features_0x37B =
+	{ "One by Wacom CTL672",    WACOM_PKGLEN_BBPEN,    21648, 13530, 2047,
+	  63, BAMBOO_PT, WACOM_INTUOS_RES, WACOM_INTUOS_RES };
 
 #define USB_DEVICE_WACOM(prod)					\
 	USB_DEVICE(USB_VENDOR_ID_WACOM, prod),			\
@@ -3441,6 +3447,8 @@ const struct usb_device_id wacom_ids[] = {
 	{ USB_DEVICE_WACOM(0x35A) },
 	{ USB_DEVICE_WACOM(0x368) },
 	{ USB_DEVICE_LENOVO(0x6004) },
+	{ USB_DEVICE_WACOM(0x37A) },
+	{ USB_DEVICE_WACOM(0x37B) },
 	{ }
 };
 MODULE_DEVICE_TABLE(usb, wacom_ids);

--- a/3.17/wacom_wac.c
+++ b/3.17/wacom_wac.c
@@ -4229,6 +4229,12 @@ static const struct wacom_features wacom_features_0x360 =
 static const struct wacom_features wacom_features_0x361 =
 	{ "Wacom Intuos Pro L", 62200, 43200, 8191, 63,
 	  INTUOSP2_BT, WACOM_INTUOS_RES, WACOM_INTUOS_RES, 9, .touch_max = 10 };
+static const struct wacom_features wacom_features_0x37A =
+	{ "One by Wacom CTL472", 14720, 9225, 2047, 63,
+	  BAMBOO_PEN, WACOM_INTUOS_RES, WACOM_INTUOS_RES };
+static const struct wacom_features wacom_features_0x37B =
+	{ "One by Wacom CTL672", 21648, 13530, 2047, 63,
+	  BAMBOO_PT, WACOM_INTUOS_RES, WACOM_INTUOS_RES };
 
 static const struct wacom_features wacom_features_HID_ANY_ID =
 	{ "Wacom HID", .type = HID_GENERIC, .oVid = HID_ANY_ID, .oPid = HID_ANY_ID };
@@ -4397,6 +4403,8 @@ const struct hid_device_id wacom_ids[] = {
 	{ USB_DEVICE_WACOM(0x343) },
 	{ BT_DEVICE_WACOM(0x360) },
 	{ BT_DEVICE_WACOM(0x361) },
+	{ USB_DEVICE_WACOM(0x37A) },
+	{ USB_DEVICE_WACOM(0x37B) },
 	{ USB_DEVICE_WACOM(0x4001) },
 	{ USB_DEVICE_WACOM(0x4004) },
 	{ USB_DEVICE_WACOM(0x5000) },

--- a/3.7/wacom_wac.c
+++ b/3.7/wacom_wac.c
@@ -3196,6 +3196,12 @@ static const struct wacom_features wacom_features_0x368 =
 	{ "Wacom DTH-1152 Touch", WACOM_PKGLEN_27QHDT,
 	  .type = DTH1152T, .touch_max = 10, .oVid = USB_VENDOR_ID_WACOM,
 	  .oPid = 0x35A }; /* Touch */
+static const struct wacom_features wacom_features_0x37A =
+	{ "One by Wacom CTL472",    WACOM_PKGLEN_BBPEN,    14720,  9225, 2047,
+	  63, BAMBOO_PT, WACOM_INTUOS_RES, WACOM_INTUOS_RES };
+static const struct wacom_features wacom_features_0x37B =
+	{ "One by Wacom CTL672",    WACOM_PKGLEN_BBPEN,    21648, 13530, 2047,
+	  63, BAMBOO_PT, WACOM_INTUOS_RES, WACOM_INTUOS_RES };
 
 #define USB_DEVICE_WACOM(prod)					\
 	USB_DEVICE(USB_VENDOR_ID_WACOM, prod),			\
@@ -3380,6 +3386,8 @@ const struct usb_device_id wacom_ids[] = {
 	{ USB_DEVICE_WACOM(0x35A) },
 	{ USB_DEVICE_WACOM(0x368) },
 	{ USB_DEVICE_LENOVO(0x6004) },
+	{ USB_DEVICE_WACOM(0x37A) },
+	{ USB_DEVICE_WACOM(0x37B) },
 	{ }
 };
 MODULE_DEVICE_TABLE(usb, wacom_ids);

--- a/4.5/wacom_wac.c
+++ b/4.5/wacom_wac.c
@@ -4317,6 +4317,12 @@ static const struct wacom_features wacom_features_0x360 =
 static const struct wacom_features wacom_features_0x361 =
 	{ "Wacom Intuos Pro L", 62200, 43200, 8191, 63,
 	  INTUOSP2_BT, WACOM_INTUOS3_RES, WACOM_INTUOS3_RES, 9, .touch_max = 10 };
+static const struct wacom_features wacom_features_0x37A =
+	{ "One by Wacom CTL472", 15200, 9500, 2047, 63,
+	  BAMBOO_PEN, WACOM_INTUOS_RES, WACOM_INTUOS_RES };
+static const struct wacom_features wacom_features_0x37B =
+	{ "One by Wacom CTL672", 21648, 13530, 2047, 63,
+	  BAMBOO_PEN, WACOM_INTUOS_RES, WACOM_INTUOS_RES };
 
 static const struct wacom_features wacom_features_HID_ANY_ID =
 	{ "Wacom HID", .type = HID_GENERIC, .oVid = HID_ANY_ID, .oPid = HID_ANY_ID };
@@ -4490,6 +4496,8 @@ const struct hid_device_id wacom_ids[] = {
 	{ USB_DEVICE_WACOM(0x5000) },
 	{ USB_DEVICE_WACOM(0x5002) },
 	{ USB_DEVICE_LENOVO(0x6004) },
+	{ USB_DEVICE_WACOM(0x37A) },
+	{ USB_DEVICE_WACOM(0x37B) },
 
 	{ USB_DEVICE_WACOM(HID_ANY_ID) },
 	{ I2C_DEVICE_WACOM(HID_ANY_ID) },


### PR DESCRIPTION
Adding support for "One by Wacom CTL472" and "One by Wacom CTL672". I simply copy the structure from CTL471/671 since the difference between CTL472/672 and CTL471/671 is only the precision of the pressure sensor (1023->2047).

Tested on my Debian 9 with Kernel=4.9.0, desktop_env=KDE

Signed-off-by: id9502 <jingmingxuan@hotmail.com>