### PR TITLE
Intuos Pro 2 BT: report pad buttons in the same order as USB

### DIFF
--- a/4.5/wacom_wac.c
+++ b/4.5/wacom_wac.c
@@ -1369,7 +1369,7 @@ static void wacom_intuos_pro2_bt_pad(struct wacom_wac *wacom)
 	struct input_dev *pad_input = wacom->pad_input;
 	unsigned char *data = wacom->data;
 
-	int buttons = (data[282] << 1) | ((data[281] >> 6) & 0x01);
+	int buttons = data[282] | ((data[281] & 0x40) << 2);
 	int ring = data[285] & 0x7F;
 	bool ringstatus = data[285] & 0x80;
 	bool prox = buttons || ringstatus;
@@ -3824,6 +3824,9 @@ static bool wacom_is_led_toggled(struct wacom *wacom, int button_count,
 				 int mask, int group)
 {
 	int button_per_group;
+
+	if (wacom->wacom_wac.features.type == INTUOSP2_BT)
+		return mask & (1<<(button_count-1));
 
 	/*
 	 * 21UX2 has LED group 1 to the left and LED group 0


### PR DESCRIPTION
Hello,
with a PTH-660 running latest firmware, the `HID_GENERIC` type handlers number the expresskeys before the scroll ring button, while the `INTUOSP2_BT` handler numbers the ring button first, which means the button numbers change depending on the connection method.

It appears the usage parser gets all of the `WACOM_HID_WD_EXPRESSKEY00` and subsequent before getting the `WACOM_HID_WD_BUTTONHOME`, which appears difficult to fix.

To fix this inconsistency this patch goes in the other direction, changing `INTUOSP2_BT` to place the ring button last. If someone can propose a good workaround for the usage ordering, then I'd be very happy to do it the other way around.