### PR TITLE
travis: Scan every commit for style issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,7 @@ install:
 
 script:
   - ./autogen.sh --with-kernel=${KERNELDIR}/${KERNEL} && make EXTRA_CFLAGS="-Werror -Wno-type-limits -Wno-unused-function -isystem ${KERNELDIR}/${KERNEL}/arch/x86/include -isystem ${KERNELDIR}/${KERNEL}/arch/x86/include/uapi -isystem ${KERNELDIR}/${KERNEL}/include/linux"
+  - git remote add upstream https://github.com/linuxwacom/input-wacom.git
+  - git fetch upstream master
+  - git format-patch FETCH_HEAD
+  - ${KERNELDIR}/${KERNEL}/scripts/checkpatch.pl *.patch


### PR DESCRIPTION
The HID and input maintainers are becoming more strict about the use of
checkpatch.pl prior to patch submission. Since development often takes
place in the input-wacom tree first and Travis already checks for various
issues, we might as well have it also perform the style checks.

Because we want to scan each commit (there could be issues with the e.g.
commit description) we write patches for every commit in this branch
which is not already on master and run checkpatch on the lot of them.

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>