### PR TITLE
travis: Properly handle commits pushed/merged to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,18 @@ install:
   - mkdir ${KERNELDIR}
   - curl ${URL} | tar xJC ${KERNELDIR}
   - if [[ ! -f ${KERNELDIR}/${KERNEL}/include/linux/compiler-gcc5.h ]]; then echo '#include <linux/compiler-gcc4.h>' > ${KERNELDIR}/${KERNEL}/include/linux/compiler-gcc5.h; fi
-  - sed -i '/duplicate signatures/,/^$/ s/if (/if (0 and /' ${KERNELDIR}/${KERNEL}/scripts/checkpatch.pl
   - make -C ${KERNELDIR}/${KERNEL} defconfig prepare modules_prepare
 
 script:
   - ./autogen.sh --with-kernel=${KERNELDIR}/${KERNEL} && make EXTRA_CFLAGS="-Werror -Wno-type-limits -Wno-unused-function -isystem ${KERNELDIR}/${KERNEL}/arch/x86/include -isystem ${KERNELDIR}/${KERNEL}/arch/x86/include/uapi -isystem ${KERNELDIR}/${KERNEL}/include/linux"
-  - git remote add upstream https://github.com/linuxwacom/input-wacom.git
-  - git fetch upstream master
-  - git format-patch FETCH_HEAD
-  - if ls *.patch 2>/dev/null; then ${KERNELDIR}/${KERNEL}/scripts/checkpatch.pl *.patch; fi
+
+jobs:
+  include:
+    stage: checkpatch
+    before_script:
+      - sed -i '/duplicate signatures/,/^$/ s/if (/if (0 and /' ${KERNELDIR}/${KERNEL}/scripts/checkpatch.pl
+      - git remote add upstream https://github.com/linuxwacom/input-wacom.git
+      - git fetch upstream master
+      - git format-patch FETCH_HEAD
+    script:
+      - if ls *.patch 2>/dev/null; then ${KERNELDIR}/${KERNEL}/scripts/checkpatch.pl *.patch; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ script:
   - git remote add upstream https://github.com/linuxwacom/input-wacom.git
   - git fetch upstream master
   - git format-patch FETCH_HEAD
-  - ${KERNELDIR}/${KERNEL}/scripts/checkpatch.pl *.patch
+  - if ls *.patch 2>/dev/null; then ${KERNELDIR}/${KERNEL}/scripts/checkpatch.pl *.patch; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
   - mkdir ${KERNELDIR}
   - curl ${URL} | tar xJC ${KERNELDIR}
   - if [[ ! -f ${KERNELDIR}/${KERNEL}/include/linux/compiler-gcc5.h ]]; then echo '#include <linux/compiler-gcc4.h>' > ${KERNELDIR}/${KERNEL}/include/linux/compiler-gcc5.h; fi
+  - sed -i '/duplicate signatures/,/^$/ s/if (/if (0 and /' ${KERNELDIR}/${KERNEL}/scripts/checkpatch.pl
   - make -C ${KERNELDIR}/${KERNEL} defconfig prepare modules_prepare
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ jobs:
       - git fetch upstream master
       - git format-patch FETCH_HEAD
     script:
-      - if ls *.patch 2>/dev/null; then ${KERNELDIR}/${KERNEL}/scripts/checkpatch.pl *.patch; fi
+      - if ls *.patch 2>/dev/null; then ${KERNELDIR}/${KERNEL}/scripts/checkpatch.pl --max-line-length=90 --ignore OPEN_BRACE --ignore EMAIL_SUBJECT *.patch; fi


### PR DESCRIPTION
Pushing or merging a branch to master updates the repository's reference
to that branch. When our travis script fetches the master branch and calls
`git format-patch` to produce a list of commits that aren't already on
master, there is obviously nothing to generate. This isn't a problem on
its own, but checkpatch the errors out with:

scripts/checkpatch.pl: *.patch: open failed - No such file or directory

To work around this we now only run checkpatch if patch files were
generated. Because we should only be pushing commits that were already
tested, this shouldn't significantly change our coverage.

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>