### PR TITLE
2.6.32: Fix incorrect case fall-through

### DIFF
--- a/2.6.32/wacom_wac.c
+++ b/2.6.32/wacom_wac.c
@@ -2299,6 +2299,9 @@ void wacom_setup_input_capabilities(struct input_dev *input_dev,
 		input_set_abs_params(input_dev, ABS_RY, 0, 4096, 0, 0);
 		input_set_abs_params(input_dev, ABS_Z, -900, 899, 0, 0);
 
+		wacom_setup_cintiq(wacom_wac);
+		break;
+
 	case INTUOS3:
 	case INTUOS3L:
 		input_set_abs_params(input_dev, ABS_RY, 0, 4096, 0, 0);
@@ -2330,6 +2333,8 @@ void wacom_setup_input_capabilities(struct input_dev *input_dev,
 			__set_bit(BTN_STYLUS3, input_dev->keybit);
 			wacom_wac->previous_ring = WACOM_INTUOSP2_RING_UNTOUCHED;
 		}
+		/* fall through */
+
 	case INTUOS5:
 	case INTUOS5L:
 	case INTUOSPM:
@@ -2414,6 +2419,7 @@ void wacom_setup_input_capabilities(struct input_dev *input_dev,
 	case DTUS2:
 	case DTK2451:
 		input_set_capability(input_dev, EV_MSC, MSC_SERIAL);
+		/* fall through */
 
 	case DTUSX:
 	case PL:

--- a/2.6.38/wacom_wac.c
+++ b/2.6.38/wacom_wac.c
@@ -2700,6 +2700,7 @@ int wacom_setup_input_capabilities(struct input_dev *input_dev,
 	case DTUS2:
 	case DTK2451:
 		input_set_capability(input_dev, EV_MSC, MSC_SERIAL);
+		/* fall through */
 
 	case DTUSX:
 	case PL:

--- a/3.7/wacom_wac.c
+++ b/3.7/wacom_wac.c
@@ -2645,6 +2645,7 @@ int wacom_setup_input_capabilities(struct input_dev *input_dev,
 	case DTUS2:
 	case DTK2451:
 		input_set_capability(input_dev, EV_MSC, MSC_SERIAL);
+		/* fall through */
 
 	case DTUSX:
 	case PL:


### PR DESCRIPTION
GCC warns about several missing fall-through comments. This commit fixes
those warnings and also addresses a real issue in the 2.6.32 tree that
results in many of the Cintiq devices being improperly initialized. The
fall-through causes these devices to be initialized as Intuos devices
rather than the Cintiqs.

wacom_wac.c: In function ‘wacom_setup_input_capabilities’:
wacom_wac.c:2300:3: error: this statement may fall through
  [-Werror=implicit-fallthrough=]
   input_set_abs_params(input_dev, ABS_Z, -900, 899, 0, 0);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
wacom_wac.c:2302:2: note: here
  case INTUOS3:
  ^~~~

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>