### PR TITLE
Error out if the build path has a space in it

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,9 +4,9 @@ srcdir=`dirname $0`
 test -z "$srcdir" && srcdir=.
 
 ORIGDIR=`pwd`
-cd $srcdir
+cd "$srcdir"
 
 autoreconf -v --install || exit 1
-cd $ORIGDIR || exit $?
+cd "$ORIGDIR" || exit $?
 
-$srcdir/configure --enable-maintainer-mode "$@"
+"$srcdir/configure" --enable-maintainer-mode "$@"

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,17 @@ AM_MAINTAINER_MODE
 AC_PROG_CC
 
 dnl =======================================================
+dnl Check if we have a sane build path
+SANITY=`readlink -e "$srcdir"`
+AC_MSG_CHECKING(if build path '$SANITY' has spaces)
+if `echo "$SANITY" | grep -q ' '`; then
+	AC_MSG_RESULT([yes])
+	AC_MSG_ERROR([Cannot build from a path with a space in it!])
+fi
+AC_MSG_RESULT([no])
+
+
+dnl =======================================================
 dnl Check if we should be compiling for linux
 AC_MSG_CHECKING(for kernel type)
 WCM_KERNEL=`uname -s`


### PR DESCRIPTION
The Linux kernel build system does not work properly if it is asked to
deal with spaces in paths. There's not much point making our own build
work in the presence of spaces, so at least for now make sure the autogen
script can run and that the generated configure script will print out an
error if this is attempted.

Ref: https://github.com/linuxwacom/input-wacom/issues/129
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>