### PR TITLE
Fix 76

### DIFF
--- a/3.17/wacom_sys.c
+++ b/3.17/wacom_sys.c
@@ -2259,6 +2259,8 @@ static int wacom_parse_and_register(struct wacom *wacom, bool wireless)
 	/* touch only Bamboo doesn't support pen */
 	if ((features->type == BAMBOO_TOUCH) &&
 	    (features->device_type & WACOM_DEVICETYPE_PEN)) {
+		cancel_delayed_work_sync(&wacom->init_work);
+		_wacom_query_tablet_data(wacom);
 		error = -ENODEV;
 		goto fail_quirks;
 	}

--- a/3.17/wacom_sys.c
+++ b/3.17/wacom_sys.c
@@ -2204,6 +2204,14 @@ static int wacom_parse_and_register(struct wacom *wacom, bool wireless)
 
 	wacom_update_name(wacom, wireless ? " (WL)" : "");
 
+	/* pen only Bamboo neither support touch nor pad */
+	if ((features->type == BAMBOO_PEN) &&
+	    ((features->device_type & WACOM_DEVICETYPE_TOUCH) ||
+	    (features->device_type & WACOM_DEVICETYPE_PAD))) {
+		error = -ENODEV;
+		goto fail_parsed;
+	}
+
 	error = wacom_add_shared_data(hdev);
 	if (error)
 		goto fail_shared_data;
@@ -2251,14 +2259,6 @@ static int wacom_parse_and_register(struct wacom *wacom, bool wireless)
 	/* touch only Bamboo doesn't support pen */
 	if ((features->type == BAMBOO_TOUCH) &&
 	    (features->device_type & WACOM_DEVICETYPE_PEN)) {
-		error = -ENODEV;
-		goto fail_quirks;
-	}
-
-	/* pen only Bamboo neither support touch nor pad */
-	if ((features->type == BAMBOO_PEN) &&
-	    ((features->device_type & WACOM_DEVICETYPE_TOUCH) ||
-	    (features->device_type & WACOM_DEVICETYPE_PAD))) {
 		error = -ENODEV;
 		goto fail_quirks;
 	}


### PR DESCRIPTION
These two commits were apparently never backported. The first fixes the crash in #76 by moving the error condition before the point at which we schedule the mode switch. The second prevents what would essentially be the same crash with a different device while ensuring it still does the (apparently required) mode switch.