### PR TITLE
Remove spurious newlines that aren't upstream

### DIFF
--- a/3.17/wacom.h
+++ b/3.17/wacom.h
@@ -251,5 +251,4 @@ void wacom_wac_report(struct hid_device *hdev, struct hid_report *report);
 void wacom_battery_work(struct work_struct *work);
 int wacom_equivalent_usage(int usage);
 int wacom_initialize_leds(struct wacom *wacom);
-
 #endif

--- a/3.17/wacom_wac.c
+++ b/3.17/wacom_wac.c
@@ -1345,7 +1345,6 @@ static void wacom_intuos_pro2_bt_pen(struct wacom_wac *wacom)
 						 get_unaligned_le16(&frame[11]));
 			}
 		}
-
 		if (wacom->tool[0]) {
 			input_report_abs(pen_input, ABS_PRESSURE, get_unaligned_le16(&frame[5]));
 			if (wacom->features.type == INTUOSP2_BT ||

--- a/4.5/wacom_wac.c
+++ b/4.5/wacom_wac.c
@@ -1333,7 +1333,6 @@ static void wacom_intuos_pro2_bt_pen(struct wacom_wac *wacom)
 						 get_unaligned_le16(&frame[11]));
 			}
 		}
-
 		if (wacom->tool[0]) {
 			input_report_abs(pen_input, ABS_PRESSURE, get_unaligned_le16(&frame[5]));
 			if (wacom->features.type == INTUOSP2_BT ||


### PR DESCRIPTION
These newlines are missing upstream. Their presence clutters up the diff
output when searching for missing patches and should be removed.

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>