### PR TITLE
Makefile fixes

### DIFF
--- a/3.17/Makefile.in
+++ b/3.17/Makefile.in
@@ -65,6 +65,7 @@ ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)
 endif
 ifdef DRACUT
+	echo 'add_drivers+=" wacom wacom_w8001 "' > /etc/dracut.conf.d/input-wacom.conf
 	$(DRACUT) -f --kver=$(MODUTS)
 endif
 
@@ -81,6 +82,7 @@ ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)
 endif
 ifdef DRACUT
+	rm -f /etc/dracut.conf.d/input-wacom.conf
 	$(DRACUT) -f --kver=$(MODUTS)
 endif
 

--- a/3.17/Makefile.in
+++ b/3.17/Makefile.in
@@ -80,6 +80,9 @@ uninstall:
 ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)
 endif
+ifdef DRACUT
+	$(DRACUT) -f --kver=$(MODUTS)
+endif
 
 endif  # End kbuild check
 

--- a/3.17/Makefile.in
+++ b/3.17/Makefile.in
@@ -59,6 +59,7 @@ install modules_install:
 	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) modules_install mod_sign_cmd='$(MODSIGN_COMMAND)'
 	mkdir -p /etc/depmod.d
 	echo "override $(MODULE_NAME) * extra" > /etc/depmod.d/input-wacom.conf
+	echo "override wacom_w8001 * extra" >> /etc/depmod.d/input-wacom.conf
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
 ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)

--- a/3.17/Makefile.in
+++ b/3.17/Makefile.in
@@ -52,13 +52,13 @@ clean:
 	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) clean
 
 signature: all
-	$(MODSIGN_COMMAND) wacom.ko
+	$(MODSIGN_COMMAND) $(MODULE_NAME).ko
 	$(MODSIGN_COMMAND) wacom_w8001.ko
 
 install modules_install:
 	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) modules_install mod_sign_cmd='$(MODSIGN_COMMAND)'
 	mkdir -p /etc/depmod.d
-	echo "override wacom * extra" > /etc/depmod.d/input-wacom.conf
+	echo "override $(MODULE_NAME) * extra" > /etc/depmod.d/input-wacom.conf
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
 ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)
@@ -72,9 +72,8 @@ uninstall:
 	@# which causes trouble for tools like 'rm' which don't
 	@# see the path how you might think. As a workaround,
 	@# first cd into the directory and then remove.
-	cd $(WCM_KERNEL_DIR)/../extra; rm -f wacom.ko*
+	cd $(WCM_KERNEL_DIR)/../extra; rm $(MODULE_NAME).ko*
 	cd $(WCM_KERNEL_DIR)/../extra; rm wacom_w8001.ko*
-	cd $(WCM_KERNEL_DIR)/../extra; rm -f hid-wacom.ko*
 	rm -f /etc/depmod.d/input-wacom.conf
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
 ifdef UPDATE_INITRAMFS

--- a/3.17/Makefile.in
+++ b/3.17/Makefile.in
@@ -65,7 +65,7 @@ ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)
 endif
 ifdef DRACUT:
-	$(DRACUT) -f /boot/initramfs-$(MODUTS).img
+	$(DRACUT) -f --kver=$(MODUTS)
 endif
 
 uninstall:

--- a/3.17/Makefile.in
+++ b/3.17/Makefile.in
@@ -64,7 +64,7 @@ install modules_install:
 ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)
 endif
-ifdef DRACUT:
+ifdef DRACUT
 	$(DRACUT) -f --kver=$(MODUTS)
 endif
 

--- a/3.7/Makefile.in
+++ b/3.7/Makefile.in
@@ -54,7 +54,7 @@ install modules_install:
 	echo "override wacom_w8001 * extra" >> /etc/depmod.d/input-wacom.conf
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
 ifdef DRACUT:
-	$(DRACUT) -f /boot/initramfs-$(MODUTS).img
+	$(DRACUT) -f --kver=$(MODUTS)
 endif
 
 uninstall:

--- a/3.7/Makefile.in
+++ b/3.7/Makefile.in
@@ -53,7 +53,7 @@ install modules_install:
 	echo "override wacom * extra" > /etc/depmod.d/input-wacom.conf
 	echo "override wacom_w8001 * extra" >> /etc/depmod.d/input-wacom.conf
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
-ifdef DRACUT:
+ifdef DRACUT
 	$(DRACUT) -f --kver=$(MODUTS)
 endif
 

--- a/3.7/Makefile.in
+++ b/3.7/Makefile.in
@@ -66,6 +66,9 @@ uninstall:
 	cd $(WCM_KERNEL_DIR)/../extra; rm wacom_w8001.ko*
 	rm -f /etc/depmod.d/input-wacom.conf
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
+ifdef DRACUT
+	$(DRACUT) -f --kver=$(MODUTS)
+endif
 
 endif  # End kbuild check
 

--- a/3.7/Makefile.in
+++ b/3.7/Makefile.in
@@ -51,6 +51,7 @@ install modules_install:
 	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) modules_install mod_sign_cmd='$(MODSIGN_COMMAND)'
 	mkdir -p /etc/depmod.d
 	echo "override wacom * extra" > /etc/depmod.d/input-wacom.conf
+	echo "override wacom_w8001 * extra" >> /etc/depmod.d/input-wacom.conf
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
 ifdef DRACUT:
 	$(DRACUT) -f /boot/initramfs-$(MODUTS).img

--- a/3.7/Makefile.in
+++ b/3.7/Makefile.in
@@ -54,6 +54,7 @@ install modules_install:
 	echo "override wacom_w8001 * extra" >> /etc/depmod.d/input-wacom.conf
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
 ifdef DRACUT
+	echo 'add_drivers+=" wacom wacom_w8001 "' > /etc/dracut.conf.d/input-wacom.conf
 	$(DRACUT) -f --kver=$(MODUTS)
 endif
 
@@ -67,6 +68,7 @@ uninstall:
 	rm -f /etc/depmod.d/input-wacom.conf
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
 ifdef DRACUT
+	rm -f /etc/dracut.conf.d/input-wacom.conf
 	$(DRACUT) -f --kver=$(MODUTS)
 endif
 

--- a/4.5/Makefile.in
+++ b/4.5/Makefile.in
@@ -58,6 +58,7 @@ ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)
 endif
 ifdef DRACUT
+	echo 'add_drivers+=" wacom wacom_w8001 "' > /etc/dracut.conf.d/input-wacom.conf
 	$(DRACUT) -f --kver=$(MODUTS)
 endif
 
@@ -74,6 +75,7 @@ ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)
 endif
 ifdef DRACUT
+	rm -f /etc/dracut.conf.d/input-wacom.conf
 	$(DRACUT) -f --kver=$(MODUTS)
 endif
 

--- a/4.5/Makefile.in
+++ b/4.5/Makefile.in
@@ -58,7 +58,7 @@ ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)
 endif
 ifdef DRACUT:
-	$(DRACUT) -f /boot/initramfs-$(MODUTS).img
+	$(DRACUT) -f --kver=$(MODUTS)
 endif
 
 uninstall:

--- a/4.5/Makefile.in
+++ b/4.5/Makefile.in
@@ -73,6 +73,9 @@ uninstall:
 ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)
 endif
+ifdef DRACUT
+	$(DRACUT) -f --kver=$(MODUTS)
+endif
 
 endif  # End kbuild check
 

--- a/4.5/Makefile.in
+++ b/4.5/Makefile.in
@@ -57,7 +57,7 @@ install modules_install:
 ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)
 endif
-ifdef DRACUT:
+ifdef DRACUT
 	$(DRACUT) -f --kver=$(MODUTS)
 endif
 

--- a/4.5/Makefile.in
+++ b/4.5/Makefile.in
@@ -52,6 +52,7 @@ install modules_install:
 	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) modules_install mod_sign_cmd='$(MODSIGN_COMMAND)'
 	mkdir -p /etc/depmod.d
 	echo "override wacom * extra" > /etc/depmod.d/input-wacom.conf
+	echo "override wacom_w8001 * extra" >> /etc/depmod.d/input-wacom.conf
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
 ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)


### PR DESCRIPTION
Fix several issues in the project's Makefiles which primarily affect RHEL / Fedora users. Correct problems with the wrong module name being used in places and the `dracut` program not being executed to update initramfs, among others.