### PR TITLE
3.7: Prevent segfault when connecting recent tablets

### DIFF
--- a/3.7/wacom_sys.c
+++ b/3.7/wacom_sys.c
@@ -1607,6 +1607,14 @@ static int wacom_register_input(struct wacom *wacom)
 	input_set_drvdata(input_dev, wacom);
 
 	wacom_wac->input = input_dev;
+
+	if (wacom_wac->features.touch_max && wacom_wac->shared) {
+		if (wacom_wac->features.device_type == BTN_TOOL_FINGER) {
+			wacom_wac->shared->type = wacom_wac->features.type;
+			wacom_wac->shared->touch_input = wacom_wac->input;
+		}
+	}
+
 	error = wacom_setup_input_capabilities(input_dev, wacom_wac);
 	if (error)
 		goto fail1;
@@ -2036,13 +2044,6 @@ static int wacom_probe(struct usb_interface *intf, const struct usb_device_id *i
 		error = wacom_initialize_remotes(wacom);
 		if (error)
 			goto fail4;
-	}
-
-	if (wacom_wac->features.touch_max && wacom_wac->shared) {
-		if (wacom_wac->features.device_type == BTN_TOOL_FINGER) {
-			wacom_wac->shared->type = wacom_wac->features.type;
-			wacom_wac->shared->touch_input = wacom_wac->input;
-		}
 	}
 
 	return 0;


### PR DESCRIPTION
Several devices can trigger a segfault when they are plugged into a
system running a 3.7 kernel (e.g. RHEL 7.0 - 7.3). The failure is due
to `wacom_wac->shared->touch_input` being null when it is dereferenced
to check the device's PID in `wacom_setup_input_capabilities` at
wacom_wac.c:2707. Affected devices have type DTH1152T, DTH2452T,
WACOM_MSPROT, and WACOM_27QHDT.

Looking through the program flow, it quickly becomes clear that the
variable is only initialized toward the end of `wacom_probe` -- well
after the call to `wacom_setup_input_capabilities`. The variables used
by the initalization code appear to all be ready by the time that we
want to make this call, however, so we should be able to safely move
it earlier.

Fixes: af0ec069e12a ("backport: HID: wacom: support named keys on older devices")
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>