### PR TITLE
configure: Fix improper version number

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -211,7 +211,7 @@ EXPLODED_VER="WCM_EXPLODE($MODUTS)"
 if test "$EXPLODED_VER" -lt "WCM_EXPLODE(3.7)"; then
 	AC_MSG_ERROR(m4_normalize([Kernels older than 3.7 are no longer supported by input-wacom.
 		 For newer Wacom models, please upgrade your system to a newer kernel.
-		 For old Wacom models, 'input-wacom-0.48.0' may still support the device]))
+		 For old Wacom models, 'input-wacom-0.47.0' may still support the device]))
 elif test "$EXPLODED_VER" -lt "WCM_EXPLODE(3.17)"; then
 	WCM_KERNEL_VER="3.7"
 elif test "$EXPLODED_VER" -lt "WCM_EXPLODE(4.5)"; then


### PR DESCRIPTION
Fixing the version number printed out for users who are using older kernels

Fixes: 5fe2ee535c0cc ("input-wacom 0.48.0")
Signed-off-by: Joshua Dickens <joshua.dickens@wacom.com>