### PR TITLE
Allow input-wacom to install both legacy and HID drivers in RHEL 7.4+

### DIFF
--- a/3.17/Makefile.in
+++ b/3.17/Makefile.in
@@ -58,8 +58,11 @@ signature: all
 install modules_install:
 	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) modules_install mod_sign_cmd='$(MODSIGN_COMMAND)'
 	mkdir -p /etc/depmod.d
-	echo "override $(MODULE_NAME) * extra" > /etc/depmod.d/input-wacom.conf
+	echo "override wacom * extra" > /etc/depmod.d/input-wacom.conf
 	echo "override wacom_w8001 * extra" >> /etc/depmod.d/input-wacom.conf
+ifeq ($(RHEL7_RELEASE),4)
+	echo "override hid-wacom * extra" >> /etc/depmod.d/input-wacom.conf
+endif # RHEL7_RELEASE
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
 ifdef UPDATE_INITRAMFS
 	$(UPDATE_INITRAMFS) -u -k $(MODUTS)

--- a/3.7/Makefile.in
+++ b/3.7/Makefile.in
@@ -1,3 +1,5 @@
+RHEL7_RELEASE := @RHEL7_RELEASE@
+
 ############################ kernel specific compile ###############################
 ifneq ($(KERNELRELEASE),)
 # We were called by kbuild
@@ -52,6 +54,9 @@ install modules_install:
 	mkdir -p /etc/depmod.d
 	echo "override wacom * extra" > /etc/depmod.d/input-wacom.conf
 	echo "override wacom_w8001 * extra" >> /etc/depmod.d/input-wacom.conf
+ifeq ($(RHEL7_RELEASE),4)
+	echo "override hid-wacom * extra" >> /etc/depmod.d/input-wacom.conf
+endif # RHEL7_RELEASE
 	PATH="$(PATH):/bin:/sbin" depmod -a $(MODUTS)
 ifdef DRACUT
 	echo 'add_drivers+=" wacom wacom_w8001 "' > /etc/dracut.conf.d/input-wacom.conf

--- a/3.7/wacom.h
+++ b/3.7/wacom.h
@@ -125,9 +125,7 @@ enum wacom_worker {
 
 struct wacom_battery {
 	struct power_supply battery;
-	struct power_supply ac;
 	char bat_name[WACOM_NAME_MAX];
-	char ac_name[WACOM_NAME_MAX];
 	int bat_status;
 	int battery_capacity;
 	int bat_charging;

--- a/3.7/wacom.h
+++ b/3.7/wacom.h
@@ -117,6 +117,10 @@ MODULE_LICENSE("GPL");
 #  define fallthrough                    do {} while (0)  /* fallthrough */
 #endif
 
+#define WACOM_POWERSUPPLY_DEVICE(ps) ((ps).dev)
+#define WACOM_POWERSUPPLY_REF(ps) (&(ps))
+#define WACOM_POWERSUPPLY_DESC(ps) (ps)
+
 enum wacom_worker {
 	WACOM_WORKER_WIRELESS,
 	WACOM_WORKER_BATTERY,

--- a/3.7/wacom.h
+++ b/3.7/wacom.h
@@ -117,9 +117,15 @@ MODULE_LICENSE("GPL");
 #  define fallthrough                    do {} while (0)  /* fallthrough */
 #endif
 
+#ifdef WACOM_POWERSUPPLY_41
+#define WACOM_POWERSUPPLY_DEVICE(ps) (ps)
+#define WACOM_POWERSUPPLY_REF(ps) (ps)
+#define WACOM_POWERSUPPLY_DESC(ps) (ps##_desc)
+#else
 #define WACOM_POWERSUPPLY_DEVICE(ps) ((ps).dev)
 #define WACOM_POWERSUPPLY_REF(ps) (&(ps))
 #define WACOM_POWERSUPPLY_DESC(ps) (ps)
+#endif
 
 enum wacom_worker {
 	WACOM_WORKER_WIRELESS,
@@ -129,7 +135,12 @@ enum wacom_worker {
 
 struct wacom_battery {
 	struct wacom *wacom;
+#ifdef WACOM_POWERSUPPLY_41
+	struct power_supply_desc bat_desc;
+	struct power_supply *battery;
+#else
 	struct power_supply battery;
+#endif
 	char bat_name[WACOM_NAME_MAX];
 	int bat_status;
 	int battery_capacity;

--- a/3.7/wacom.h
+++ b/3.7/wacom.h
@@ -124,6 +124,7 @@ enum wacom_worker {
 };
 
 struct wacom_battery {
+	struct wacom *wacom;
 	struct power_supply battery;
 	char bat_name[WACOM_NAME_MAX];
 	int bat_status;

--- a/3.7/wacom_sys.c
+++ b/3.7/wacom_sys.c
@@ -1303,17 +1303,17 @@ static int wacom_initialize_battery(struct wacom *wacom)
 
 static void wacom_destroy_battery(struct wacom *wacom)
 {
-	if (wacom->battery.battery.dev) {
-		power_supply_unregister(&wacom->battery.battery);
-		wacom->battery.battery.dev = NULL;
+	if (WACOM_POWERSUPPLY_DEVICE(wacom->battery.battery)) {
+		power_supply_unregister(WACOM_POWERSUPPLY_REF(wacom->battery.battery));
+		WACOM_POWERSUPPLY_DEVICE(wacom->battery.battery) = NULL;
 	}
 }
 
 static void wacom_destroy_remote_battery(struct wacom_battery *battery)
 {
-	if (battery->battery.dev) {
-		power_supply_unregister(&battery->battery);
-		battery->battery.dev = NULL;
+	if (WACOM_POWERSUPPLY_DEVICE(battery->battery)) {
+		power_supply_unregister(WACOM_POWERSUPPLY_REF(battery->battery));
+		WACOM_POWERSUPPLY_DEVICE(battery->battery) = NULL;
 	}
 }
 
@@ -1416,7 +1416,7 @@ static void wacom_remote_destroy_one(struct wacom *wacom, unsigned int index)
 	if (remote->remotes[index].input)
 		input_unregister_device(remote->remotes[index].input);
 
-	if (remote->remotes[index].battery.battery.dev)
+	if (WACOM_POWERSUPPLY_DEVICE(remote->remotes[index].battery.battery))
 		wacom_destroy_remote_battery(&remote->remotes[index].battery);
 
 	for (i = 0; i < WACOM_MAX_REMOTES; i++) {
@@ -1429,7 +1429,7 @@ static void wacom_remote_destroy_one(struct wacom *wacom, unsigned int index)
 			kfree((char *)remote->remotes[i].group.name);
 			remote->remotes[i].group.name = NULL;
 			remote->remotes[i].registered = false;
-			remote->remotes[i].battery.battery.dev = NULL;
+			WACOM_POWERSUPPLY_DEVICE(remote->remotes[i].battery.battery) = NULL;
 			wacom->led.select[i] = WACOM_STATUS_UNKNOWN;
 		}
 	}
@@ -1715,7 +1715,7 @@ static int wacom_remote_attach_battery(struct wacom *wacom, int index)
 	if (!remote->remotes[index].registered)
 		return 0;
 
-	if (remote->remotes[index].battery.battery.dev)
+	if (WACOM_POWERSUPPLY_DEVICE(remote->remotes[index].battery.battery))
 		return 0;
 
 	error = __wacom_initialize_battery(wacom,
@@ -1871,11 +1871,11 @@ void wacom_battery_work(struct work_struct *work)
 	struct wacom *wacom = container_of(work, struct wacom, battery_work);
 
 	if ((wacom->wacom_wac.features.quirks & WACOM_QUIRK_BATTERY) &&
-	     !wacom->battery.battery.dev) {
+	     !WACOM_POWERSUPPLY_DEVICE(wacom->battery.battery)) {
 		wacom_initialize_battery(wacom);
 	}
 	else if (!(wacom->wacom_wac.features.quirks & WACOM_QUIRK_BATTERY) &&
-		 wacom->battery.battery.dev) {
+		 WACOM_POWERSUPPLY_DEVICE(wacom->battery.battery)) {
 		wacom_destroy_battery(wacom);
 	}
 }

--- a/3.7/wacom_sys.c
+++ b/3.7/wacom_sys.c
@@ -1208,6 +1208,7 @@ static int wacom_initialize_leds(struct wacom *wacom)
 }
 
 static enum power_supply_property wacom_battery_props[] = {
+	POWER_SUPPLY_PROP_MODEL_NAME,
 	POWER_SUPPLY_PROP_PRESENT,
 	POWER_SUPPLY_PROP_STATUS,
 	POWER_SUPPLY_PROP_SCOPE,
@@ -1222,6 +1223,9 @@ static int wacom_battery_get_property(struct power_supply *psy,
 	int ret = 0;
 
 	switch (psp) {
+		case POWER_SUPPLY_PROP_MODEL_NAME:
+			val->strval = battery->wacom->wacom_wac.name;
+			break;
 		case POWER_SUPPLY_PROP_PRESENT:
 			val->intval = battery->bat_connected;
 			break;

--- a/3.7/wacom_wac.c
+++ b/3.7/wacom_wac.c
@@ -72,8 +72,8 @@ static void __wacom_notify_battery(struct wacom_battery *battery,
 		battery->bat_connected = bat_connected;
 		battery->ps_connected = ps_connected;
 
-		if (battery->battery.dev)
-			power_supply_changed(&battery->battery);
+		if (WACOM_POWERSUPPLY_DEVICE(battery->battery))
+			power_supply_changed(WACOM_POWERSUPPLY_REF(battery->battery));
 	}
 }
 
@@ -1831,14 +1831,14 @@ static int wacom_status_irq(struct wacom_wac *wacom_wac, size_t len)
 		wacom_notify_battery(wacom_wac, WACOM_POWER_SUPPLY_STATUS_AUTO,
 				     battery, charging, battery || charging, 1);
 
-		if (!wacom->battery.battery.dev &&
+		if (!WACOM_POWERSUPPLY_DEVICE(wacom->battery.battery) &&
 		    !(features->quirks & WACOM_QUIRK_BATTERY)) {
 			features->quirks |= WACOM_QUIRK_BATTERY;
 			wacom_schedule_work(wacom_wac, WACOM_WORKER_BATTERY);
 		}
 	}
 	else if ((features->quirks & WACOM_QUIRK_BATTERY) &&
-		 wacom->battery.battery.dev) {
+		 WACOM_POWERSUPPLY_DEVICE(wacom->battery.battery)) {
 		features->quirks &= ~WACOM_QUIRK_BATTERY;
 		wacom_schedule_work(wacom_wac, WACOM_WORKER_BATTERY);
 		wacom_notify_battery(wacom_wac, POWER_SUPPLY_STATUS_UNKNOWN, 0, 0, 0, 0);
@@ -1876,7 +1876,7 @@ static int wacom_mspro_device_irq(struct wacom_wac *wacom)
 	battery_level = data[1] & 0x7F;
 	bat_charging = data[1] & 0x80;
 
-	if (!w->battery.battery.dev &&
+	if (!WACOM_POWERSUPPLY_DEVICE(w->battery.battery) &&
 	    !(features->quirks & WACOM_QUIRK_BATTERY)) {
 		features->quirks |= WACOM_QUIRK_BATTERY;
 		wacom_schedule_work(wacom, WACOM_WORKER_BATTERY);

--- a/configure.ac
+++ b/configure.ac
@@ -220,9 +220,9 @@ else
 	WCM_KERNEL_VER="4.5"
 fi
 
-dnl overwrite for RHEL distribution
+dnl Build both legacy and hid versions
 if test "$RHEL7_RELEASE" -ge "4"; then
-        WCM_KERNEL_VER="3.17"
+        WCM_KERNEL_VER+=" 3.17"
 fi
 
 dnl =======================================================


### PR DESCRIPTION
This series of commits backports support for the RHEL 7.4+ power_supply interface to our legacy 3.7 tree. In addition it updates the makefiles to build and install the legacy driver alongside the HID driver.