### PR TITLE
backport: HID: wacom: Use "Confidence" flag to prevent reporting invalid contacts

### DIFF
--- a/3.17/wacom_wac.c
+++ b/3.17/wacom_wac.c
@@ -2619,6 +2619,9 @@ static void wacom_wac_finger_event(struct hid_device *hdev,
 		return;
 
 	switch (equivalent_usage) {
+	case HID_DG_CONFIDENCE:
+		wacom_wac->hid_data.confidence = value;
+		break;
 	case HID_GD_X:
 		wacom_wac->hid_data.x = value;
 		break;
@@ -2651,7 +2654,8 @@ static void wacom_wac_finger_event(struct hid_device *hdev,
 	}
 
 	if (usage->usage_index + 1 == field->report_count) {
-		if (equivalent_usage == wacom_wac->hid_data.last_slot_field)
+		if (equivalent_usage == wacom_wac->hid_data.last_slot_field &&
+		    wacom_wac->hid_data.confidence)
 			wacom_wac_finger_slot(wacom_wac, wacom_wac->touch_input);
 	}
 }
@@ -2668,6 +2672,8 @@ static void wacom_wac_finger_pre_report(struct hid_device *hdev,
 		return;
 
 	wacom_wac->is_invalid_bt_frame = false;
+
+	hid_data->confidence = true;
 
 	for (i = 0; i < report->maxfield; i++) {
 		struct hid_field *field = report->field[i];

--- a/3.17/wacom_wac.h
+++ b/3.17/wacom_wac.h
@@ -321,6 +321,7 @@ struct hid_data {
 	bool barrelswitch;
 	bool barrelswitch2;
 	bool serialhi;
+	bool confidence;
 	int x;
 	int y;
 	int pressure;

--- a/3.7/wacom_wac.c
+++ b/3.7/wacom_wac.c
@@ -1299,6 +1299,7 @@ static int wacom_multitouch_generic(struct wacom_wac *wacom)
 		int c_y = -1;
 		int prox = -1;
 		int offset = bytes_per_packet * i + bytes_header;
+		bool confidence = true;
 
 		switch (features->type) {
 		case WACOM_24HDT:
@@ -1323,6 +1324,7 @@ static int wacom_multitouch_generic(struct wacom_wac *wacom)
 		case DTH1152T:
 		case DTH2452T:
 			prox = data[offset] & 0x1;
+			confidence = data[offset] & 0x4;
 			contact_id = get_unaligned_le16(&data[offset + 1]);
 			x = get_unaligned_le16(&data[offset + 3]);
 			y = get_unaligned_le16(&data[offset + 5]);
@@ -1343,7 +1345,8 @@ static int wacom_multitouch_generic(struct wacom_wac *wacom)
 		default:
 			continue;
 		}
-
+		if (!confidence)
+			continue;
 		wacom_multitouch_generic_finger(wacom, contact_id, prox, x, y, w, h, c_x, c_y);
 	}
 

--- a/4.5/wacom_wac.c
+++ b/4.5/wacom_wac.c
@@ -2612,6 +2612,9 @@ static void wacom_wac_finger_event(struct hid_device *hdev,
 		return;
 
 	switch (equivalent_usage) {
+	case HID_DG_CONFIDENCE:
+		wacom_wac->hid_data.confidence = value;
+		break;
 	case HID_GD_X:
 		wacom_wac->hid_data.x = value;
 		break;
@@ -2644,7 +2647,8 @@ static void wacom_wac_finger_event(struct hid_device *hdev,
 	}
 
 	if (usage->usage_index + 1 == field->report_count) {
-		if (equivalent_usage == wacom_wac->hid_data.last_slot_field)
+		if (equivalent_usage == wacom_wac->hid_data.last_slot_field &&
+		    wacom_wac->hid_data.confidence)
 			wacom_wac_finger_slot(wacom_wac, wacom_wac->touch_input);
 	}
 }
@@ -2661,6 +2665,8 @@ static void wacom_wac_finger_pre_report(struct hid_device *hdev,
 		return;
 
 	wacom_wac->is_invalid_bt_frame = false;
+
+	hid_data->confidence = true;
 
 	for (i = 0; i < report->maxfield; i++) {
 		struct hid_field *field = report->field[i];

--- a/4.5/wacom_wac.h
+++ b/4.5/wacom_wac.h
@@ -321,6 +321,7 @@ struct hid_data {
 	bool barrelswitch;
 	bool barrelswitch2;
 	bool serialhi;
+	bool confidence;
 	int x;
 	int y;
 	int pressure;

--- a/configure.ac
+++ b/configure.ac
@@ -211,7 +211,7 @@ EXPLODED_VER="WCM_EXPLODE($MODUTS)"
 if test "$EXPLODED_VER" -lt "WCM_EXPLODE(3.7)"; then
 	AC_MSG_ERROR(m4_normalize([Kernels older than 3.7 are no longer supported by input-wacom.
 		 For newer Wacom models, please upgrade your system to a newer kernel.
-		 For old Wacom models, 'input-wacom-0.48.0' may still support the device]))
+		 For old Wacom models, 'input-wacom-0.47.0' may still support the device]))
 elif test "$EXPLODED_VER" -lt "WCM_EXPLODE(3.17)"; then
 	WCM_KERNEL_VER="3.7"
 elif test "$EXPLODED_VER" -lt "WCM_EXPLODE(4.5)"; then


### PR DESCRIPTION
The HID descriptor of many of Wacom's touch input devices include a
"Confidence" usage that signals if a particular touch collection contains
useful data. The driver does not look at this flag, however, which causes
even invalid contacts to be reported to userspace. A lucky combination of
kernel event filtering and device behavior (specifically: contact ID 0 ==
invalid, contact ID >0 == valid; and order all data so that all valid
contacts are reported before any invalid contacts) spare most devices from
any visibly-bad behavior.

The DTH-2452 is one example of an unlucky device that misbehaves. It uses
ID 0 for both the first valid contact and all invalid contacts. Because
we report both the valid and invalid contacts, the kernel reports that
contact 0 first goes down (valid) and then goes up (invalid) in every
report. This causes ~100 clicks per second simply by touching the screen.

This patch introduces new `confidence` flag in our `hid_data` structure.
The value is initially set to `true` at the start of a report and can be
set to `false` if an invalid touch usage is seen.

Link: linuxwacom#270
Fixes: f8b6a74719b5 ("HID: wacom: generic: Support multiple tools per report")
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>
Tested-by: Joshua Dickens <joshua.dickens@wacom.com>
Cc: <stable@vger.kernel.org>
Signed-off-by: Jiri Kosina <jkosina@suse.cz>
[joshua.dickens@wacom.com: Imported into input-wacom repository (7fb0413baa7f)]
Signed-off-by: Joshua Dickens <joshua.dickens@wacom.com>
[joshua.dickens@wacom.com: Backported from input-wacom repository (c2dbbba)]
Signed-off-by: Joshua Dickens <joshua.dickens@wacom.com>