### PR TITLE
github: Add '-Wno-error=pointer-sign' to 4.5+ builds for I2C driver

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,13 +22,13 @@ jobs:
           - kernel: "4.1"
             compile_cflags: -Wno-error=format-truncation
           - kernel: "4.5"
-            compile_cflags: -Wno-error=format-truncation
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
           - kernel: "4.6"
-            compile_cflags: -Wno-error=format-truncation
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
           - kernel: "4.14"
-            compile_cflags: -Wno-error=format-truncation
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
           - kernel: "5.10"
-            compile_cflags: -Wno-error=format-truncation
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
The interface to the I2C subsystem expects to be passed buffers of type
char *, but our driver (and the vast majority of other I2C drivers, for
what its worth) passes a u8 * buffer instead. GCC generates a pointer
sign warning in response, but this causes the github build to fail since
we have '-Werror' enabled.

While we work on trying to fix the upstream I2C interface, work around
this problem by not erroring out on pointer-sign warnings from affected
kernel versions.

Link: https://lore.kernel.org/all/20220718153448.173652-1-jason.gerecke@wacom.com/
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>