### PR TITLE
Sync trivial changes from upstream into trees

### DIFF
--- a/3.17/wacom_wac.c
+++ b/3.17/wacom_wac.c
@@ -1397,6 +1397,7 @@ static void wacom_intuos_pro2_bt_pen(struct wacom_wac *wacom)
 						 get_unaligned_le16(&frame[11]));
 			}
 		}
+
 		if (wacom->tool[0]) {
 			input_report_abs(pen_input, ABS_PRESSURE, get_unaligned_le16(&frame[5]));
 			if (wacom->features.type == INTUOSP2_BT ||

--- a/4.5/wacom_wac.c
+++ b/4.5/wacom_wac.c
@@ -72,7 +72,7 @@ void wacom_idleprox_timeout(struct timer_list *list)
 #else
 void wacom_idleprox_timeout(unsigned long data)
 {
-       struct wacom *wacom = (struct wacom *)data;
+	struct wacom *wacom = (struct wacom *)data;
 #endif
 	struct wacom_wac *wacom_wac = &wacom->wacom_wac;
 
@@ -1973,7 +1973,6 @@ static void wacom_map_usage(struct input_dev *input, struct hid_usage *usage,
 				 code);
 		}
 		input_abs_set_res(input, code, resolution);
- 		break;
 		break;
 	case EV_KEY:
 	case EV_MSC:


### PR DESCRIPTION
There have been some trivial changes made upstream that are missing from input-wacom. This copies them over so that the trees are in closer sync with each other.