### PR TITLE
3.17: Change conditional compilation of devm_add_action_or_reset

### DIFF
--- a/3.17/wacom_sys.c
+++ b/3.17/wacom_sys.c
@@ -62,7 +62,7 @@ static bool wacom_is_using_usb_driver(struct hid_device *hdev)
 	       usb_for_each_dev(hdev, __wacom_is_usb_parent);
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
+#ifndef WACOM_DEVM_OR_RESET
 static int devm_add_action_or_reset(struct device *dev,
 				    void (*action)(void *), void *data)
 {

--- a/configure.ac
+++ b/configure.ac
@@ -205,6 +205,21 @@ struct power_supply_desc test;
 	AC_MSG_RESULT([pre-v4.1])
 ])
 
+dnl RedHat enterprise Linux 7.9 backports devm functions from 4.6
+AC_MSG_CHECKING(devm_add_action_or_reset)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/device.h>
+int devm_add_action_or_reset(struct device *dev, void (*action)(void *), void *data) { return 0; }
+],[
+],[
+	HAVE_DEVM_ADD_OR_RESET=no
+	AC_MSG_RESULT([no])
+],[
+	HAVE_DEVM_ADD_OR_RESET=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_DEVM_OR_RESET], [], [kernel defines devm_add_action_or_reset from v4.6+])
+])
+
 dnl Check which version of the driver we should compile
 AC_DEFUN([WCM_EXPLODE], [$(echo "$1" | awk '{split($[0],x,"[[^0-9]]"); printf("%03d%03d%03d\n",x[[1]],x[[2]],x[[3]]);}')])
 EXPLODED_VER="WCM_EXPLODE($MODUTS)"


### PR DESCRIPTION
While this function was indeed added in v4.6 of the Linux kernel, it has also been backported to RHEL 7.9. Because RHEL declares itself to use a 3.10 kernel, however, the compile fails with the following error about a redefined symbol:

./3.17/wacom_sys.c:66:12: error: redefinition of ‘devm_add_action_or_reset’
 static int devm_add_action_or_reset(struct device *dev,
            ^
In file included from include/linux/input.h:22:0,
                 from include/linux/hid.h:35,
                 from /home/mocaw/input-wacom/3.17/wacom_wac.h:7,
                 from /home/mocaw/input-wacom/3.17/wacom_sys.c:6:
include/linux/device.h:683:19: note: previous definition of ‘devm_add_action_or_reset’ was here
 static inline int devm_add_action_or_reset(struct device *dev,
                   ^

This commit adds a configure-time check for this function (like we do for the power_supply APIs) so that code will compile properly regardless of the declared kernel version.


**NOTE:** While we're waiting for the strscpy patch to be pulled upstream, you can see the actual compile results for this branch at https://github.com/jigpu/input-wacom/actions/runs/4862869311