### PR TITLE
Fix compile issues with Linux 6.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        kernel: ["5.10", "4.14", "4.6", "4.5", "4.1", "3.19", "3.18", "3.17", "3.7"]
+        kernel: ["6.3", "5.10", "4.14", "4.6", "4.5", "4.1", "3.19", "3.18", "3.17", "3.7"]
         include:
           - kernel: "3.7"
             compile_cflags: -fno-pie -Wno-error=pointer-sign
@@ -35,6 +35,8 @@ jobs:
           - kernel: "4.14"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
           - kernel: "5.10"
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+          - kernel: "6.3"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
     steps:
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
           - kernel: "6.3"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+            build_makeflags: KBUILD_MODPOST_WARN=1
     steps:
       - name: Install dependencies
         run: |
@@ -88,5 +89,5 @@ jobs:
           KERNELDIR=${HOME}/kernel
           KERNELROOT=${KERNELDIR}/linux-${{ matrix.kernel }}
           ./autogen.sh --with-kernel=${KERNELROOT}
-          make V=1 EXTRA_CFLAGS="${COMPILE_CFLAGS} ${{ matrix.compile_cflags }}"
+          make V=1 EXTRA_CFLAGS="${COMPILE_CFLAGS} ${{ matrix.compile_cflags }}" EXTRA_MAKEFLAGS="${BUILD_MAKEFLAGS} ${{ matrix.build_makeflags }}"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,8 @@
 on: [ push, pull_request ]
 
 env:
-  COMPILE_CFLAGS: -fno-pie -Werror
-  PREPARE_CFLAGS: -fno-pie
+  COMPILE_CFLAGS: -Werror
+  PREPARE_CFLAGS:
 
 jobs:
   compile:
@@ -12,24 +12,36 @@ jobs:
         kernel: ["5.10", "4.14", "4.6", "4.5", "4.1", "3.19", "3.18", "3.17", "3.7"]
         include:
           - kernel: "3.7"
-            compile_cflags: -Wno-error=pointer-sign
+            compile_cflags: -fno-pie -Wno-error=pointer-sign
+            prepare_cflags: -fno-pie -no-pie
           - kernel: "3.17"
-            compile_cflags: -Wno-error=format-truncation
+            compile_cflags: -fno-pie -Wno-error=format-truncation
+            prepare_cflags: -fno-pie -no-pie
           - kernel: "3.18"
-            compile_cflags: -Wno-error=format-truncation
+            compile_cflags: -fno-pie -Wno-error=format-truncation
+            prepare_cflags: -fno-pie -no-pie
           - kernel: "3.19"
-            compile_cflags: -Wno-error=format-truncation
+            compile_cflags: -fno-pie -Wno-error=format-truncation
+            prepare_cflags: -fno-pie -no-pie
           - kernel: "4.1"
-            compile_cflags: -Wno-error=format-truncation
+            compile_cflags: -fno-pie -Wno-error=format-truncation
+            prepare_cflags: -fno-pie -no-pie
           - kernel: "4.5"
-            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign
+            prepare_cflags: -fno-pie -no-pie
           - kernel: "4.6"
-            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign
+            prepare_cflags: -fno-pie -no-pie
           - kernel: "4.14"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
           - kernel: "5.10"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get install gcc-9-plugin-dev libelf-dev
+          gcc -print-file-name=plugin
+
       - name: Checkout the repo
         uses: actions/checkout@v2
 

--- a/3.17/Makefile.in
+++ b/3.17/Makefile.in
@@ -46,7 +46,7 @@ endif
 
 all:
 	@echo '    Building input-wacom drivers for $(WCM_KERNEL_VER) kernel.'
-	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD)
+	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) $(EXTRA_MAKEFLAGS)
 
 clean:
 	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) clean

--- a/3.7/Makefile.in
+++ b/3.7/Makefile.in
@@ -40,7 +40,7 @@ endif
 
 all:
 	@echo '    Building input-wacom drivers for $(WCM_VERSION_VER) kernel.'
-	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD)
+	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) $(EXTRA_MAKEFLAGS)
 
 clean:
 	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) clean

--- a/4.5/Makefile.in
+++ b/4.5/Makefile.in
@@ -40,7 +40,7 @@ endif
 
 all:
 	@echo '    Building input-wacom drivers for $(WCM_KERNEL_VER) kernel.'
-	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD)
+	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) $(EXTRA_MAKEFLAGS)
 
 clean:
 	$(MAKE) -C $(WCM_KERNEL_DIR) M=$(PWD) clean

--- a/4.5/wacom_i2c.c
+++ b/4.5/wacom_i2c.c
@@ -6,6 +6,8 @@
  * <tobita.tatsunosuke@wacom.co.jp>
  */
 
+#include "../config.h"
+
 #include <linux/module.h>
 #include <linux/input.h>
 #include <linux/i2c.h>

--- a/4.5/wacom_i2c.c
+++ b/4.5/wacom_i2c.c
@@ -177,8 +177,12 @@ static void wacom_i2c_close(struct input_dev *dev)
 	disable_irq(client->irq);
 }
 
+#ifdef WACOM_PROBE_LEGACY
 static int wacom_i2c_probe(struct i2c_client *client,
 			   const struct i2c_device_id *id)
+#else
+static int wacom_i2c_probe(struct i2c_client *client)
+#endif
 {
 	struct device *dev = &client->dev;
 	struct wacom_i2c *wac_i2c;

--- a/4.5/wacom_sys.c
+++ b/4.5/wacom_sys.c
@@ -14,7 +14,11 @@
 #define DEV_ATTR_WO_PERM (S_IWUSR | S_IWGRP)
 #define DEV_ATTR_RO_PERM (S_IRUSR | S_IRGRP)
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
+#if defined WACOM_HID_IS_USB
+#define wacom_is_using_usb_driver(hdev) hid_is_usb(hdev)
+#elif defined WACOM_USING_LL_DRIVER
+#define wacom_is_using_usb_driver(hdev) hid_is_using_ll_driver(hdev, &usb_hid_driver)
+#else
 static int __wacom_is_usb_parent(struct usb_device *usbdev, void *ptr)
 {
 	struct hid_device *hdev = ptr;
@@ -34,8 +38,6 @@ static bool wacom_is_using_usb_driver(struct hid_device *hdev)
 	return hdev->bus == BUS_USB &&
 	       usb_for_each_dev(hdev, __wacom_is_usb_parent);
 }
-#else
-#define wacom_is_using_usb_driver(hdev) hid_is_using_ll_driver(hdev, &usb_hid_driver)
 #endif
 
 #ifndef WACOM_DEVM_OR_RESET

--- a/4.5/wacom_sys.c
+++ b/4.5/wacom_sys.c
@@ -38,7 +38,7 @@ static bool wacom_is_using_usb_driver(struct hid_device *hdev)
 #define wacom_is_using_usb_driver(hdev) hid_is_using_ll_driver(hdev, &usb_hid_driver)
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
+#ifndef WACOM_DEVM_OR_RESET
 static int devm_add_action_or_reset(struct device *dev,
 				    void (*action)(void *), void *data)
 {

--- a/configure.ac
+++ b/configure.ac
@@ -250,6 +250,26 @@ bool hid_is_usb(struct hid_device *hdev) { return 0; }
 	AC_DEFINE([WACOM_HID_IS_USB], [], [kernel defines hid_is_usb from v5.15+])
 ])
 
+dnl Check which API style the I2C subsystem uses for probing.
+dnl The old-style was deprecated in Linux 4.10 and a "probe_new" function
+dnl introduced during the transition. The old-style was removed and
+dnl "probe_new" renamed in Linux 6.3.
+AC_MSG_CHECKING(legacy I2C probe API)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/i2c.h>
+int probe_legacy(struct i2c_client *client, const struct i2c_device_id *id);
+],[
+struct i2c_driver test = { .probe = probe_legacy };
+],[
+	HAVE_I2C_PROBE_LEGACY=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_PROBE_LEGACY], [], [legacy .probe removed in v6.3 and later])
+],[
+	HAVE_I2C_PROBE_LEGACY=no
+	AC_MSG_RESULT([no])
+])
+
+
 dnl Check which version of the driver we should compile
 AC_DEFUN([WCM_EXPLODE], [$(echo "$1" | awk '{split($[0],x,"[[^0-9]]"); printf("%03d%03d%03d\n",x[[1]],x[[2]],x[[3]]);}')])
 EXPLODED_VER="WCM_EXPLODE($MODUTS)"

--- a/configure.ac
+++ b/configure.ac
@@ -222,6 +222,34 @@ int devm_add_action_or_reset(struct device *dev, void (*action)(void *), void *d
 	AC_DEFINE([WACOM_DEVM_OR_RESET], [], [kernel defines devm_add_action_or_reset from v4.6+])
 ])
 
+dnl Check which API is available for determining bus type
+AC_MSG_CHECKING(hid_is_using_ll_driver)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/hid.h>
+bool hid_is_using_ll_driver(struct hid_device *hdev, struct hid_ll_driver *driver) { return 0; }
+],[
+],[
+	HAVE_IS_USING_LL_DRIVER=no
+	AC_MSG_RESULT([no])
+],[
+	HAVE_IS_USING_LL_DRIVER=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_USING_LL_DRIVER], [], [kernel defines hid_is_using_ll_driver from v4.14+])
+])
+AC_MSG_CHECKING(hid_is_usb)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/hid.h>
+bool hid_is_usb(struct hid_device *hdev) { return 0; }
+],[
+],[
+	HAVE_HID_IS_USB=no
+	AC_MSG_RESULT([no])
+],[
+	HAVE_HID_IS_USB=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_HID_IS_USB], [], [kernel defines hid_is_usb from v5.15+])
+])
+
 dnl Check which version of the driver we should compile
 AC_DEFUN([WCM_EXPLODE], [$(echo "$1" | awk '{split($[0],x,"[[^0-9]]"); printf("%03d%03d%03d\n",x[[1]],x[[2]],x[[3]]);}')])
 EXPLODED_VER="WCM_EXPLODE($MODUTS)"

--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,8 @@ $2
   ;
   return 0;
 }
+#include "linux/module.h"
+MODULE_LICENSE("GPL");
 ])
 
 dnl #


### PR DESCRIPTION
This set of commits address the problems with building input-wacom on the Linux 6.3 kernel. In addition, it updates the Github actions to add version 6.3 to the test matrix. Some background work is required for each of these tasks, e.g. adding new checks to `configure.ac`, having wacom_i2c.c use our `config.h` header, and modifying the cflags / makeflags used in the Github build. This is why the list of commits is more than just a quick two or three changes.