### PR TITLE
Update checkpatch to run only when kernel files are touched

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,4 +1,8 @@
-on: [ pull_request ]
+on:
+  pull_request:
+    paths:
+    - '3.17/**'
+    - '4.5/**'
 
 jobs:
   checkpatch:


### PR DESCRIPTION
A quick update to only run checkpatch when kernel files are touched so it is only run when we actually need it.