### PR TITLE
github: Run 'apt-get update' before 'apt-get install'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install gcc-9-plugin-dev libelf-dev
           gcc -print-file-name=plugin
 


### PR DESCRIPTION
Ensure we have an up-to-date version of the package index before trying to install packages. Otherwise we may try to install an outdated version of something that has been deleted from Ubuntu's servers.