### PR TITLE
github: Minimize permissions granted to automated workflows / jobs

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -4,6 +4,9 @@ on:
     - '3.17/**'
     - '4.5/**'
 
+permissions:
+  contents: read
+
 jobs:
   checkpatch:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 env:
   COMPILE_CFLAGS: -Werror
   PREPARE_CFLAGS:

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -6,10 +6,15 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   tagged-release:
     name: "Tagged Release"
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: write
 
     steps:
       # ...


### PR DESCRIPTION
Jobs that use the GITHUB_TOKEN to perform sensitive actions on behalf of a real user may be granted a range of permissions. Instead of granting blanket permissions to read and write "all" APIs, we should really limit the permissions what any individual workflow or job can do.

This commit sets the default permissions for each workflow to "contents: read", which allows jobs to only read from the repository. The one job that requires additional permission is our "tagged_release" job which additional requires write access.

Link: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions
Link: https://github.com/linuxwacom/input-wacom/pull/317