### PR TITLE
github: Update to use 'checkout@v4' action to avoid Node.js warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           gcc -print-file-name=plugin
 
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download and extract v${{ matrix.kernel }} kernel
         run: |


### PR DESCRIPTION
The following warning is displayed multiple times in the "Annotations" section of a Github action that runs the main workflow:

~~~
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. ~~~

Updating the main workflow to use checkout@v4 elimiates this warning.