### PR TITLE
git-version-gen: modify "TAG_PREFIX" content

### DIFF
--- a/git-version-gen
+++ b/git-version-gen
@@ -2,7 +2,7 @@
 
 DIRECTORY=$(basename "$(dirname "$(readlink -mn "$0")")")
 DEF_VER="$DIRECTORY"
-TAG_PREFIX="input-wacom-"
+TAG_PREFIX="v"
 LF='
 '
 


### PR DESCRIPTION
"TAG_PREFIX" contains the tag release prefix.
It was changed to "v" from "input-wacom-" in order to follow the new release tag string.