### PR TITLE
Import w8001 patch from upstream

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,22 +30,22 @@ jobs:
             compile_cflags: -fno-pie -Wno-error=format-truncation
             prepare_cflags: -fno-pie -no-pie
           - kernel: "4.5"
-            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign
+            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
             prepare_cflags: -fno-pie -no-pie
           - kernel: "4.6"
-            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign
+            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
             prepare_cflags: -fno-pie -no-pie
           - kernel: "4.10"
-            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign
+            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
             prepare_cflags: -fno-pie -no-pie
           - kernel: "4.14"
-            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
           - kernel: "4.19"
-            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
           - kernel: "5.10"
-            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
           - kernel: "6.3"
-            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
             build_makeflags: KBUILD_MODPOST_WARN=1
     steps:
       - name: Install dependencies

--- a/4.5/wacom_w8001.c
+++ b/4.5/wacom_w8001.c
@@ -625,7 +625,7 @@ static int w8001_connect(struct serio *serio, struct serio_driver *drv)
 	/* For backwards-compatibility we compose the basename based on
 	 * capabilities and then just append the tool type
 	 */
-	strlcpy(basename, "Wacom Serial", sizeof(basename));
+	strscpy(basename, "Wacom Serial", sizeof(basename));
 
 	err_pen = w8001_setup_pen(w8001, basename, sizeof(basename));
 	err_touch = w8001_setup_touch(w8001, basename, sizeof(basename));
@@ -635,7 +635,7 @@ static int w8001_connect(struct serio *serio, struct serio_driver *drv)
 	}
 
 	if (!err_pen) {
-		strlcpy(w8001->pen_name, basename, sizeof(w8001->pen_name));
+		strscpy(w8001->pen_name, basename, sizeof(w8001->pen_name));
 		strlcat(w8001->pen_name, " Pen", sizeof(w8001->pen_name));
 		input_dev_pen->name = w8001->pen_name;
 
@@ -651,7 +651,7 @@ static int w8001_connect(struct serio *serio, struct serio_driver *drv)
 	}
 
 	if (!err_touch) {
-		strlcpy(w8001->touch_name, basename, sizeof(w8001->touch_name));
+		strscpy(w8001->touch_name, basename, sizeof(w8001->touch_name));
 		strlcat(w8001->touch_name, " Finger",
 			sizeof(w8001->touch_name));
 		input_dev_touch->name = w8001->touch_name;


### PR DESCRIPTION
Imports the following upstream commit: `Input: move from strlcpy with unused retval to strscpy` (a9f08ad7adb3). The strlcpy function is removed in Linux 6.9, which prevents input-wacom from compiling without this commit. The import only applies to the 4.5 branch since strscpy is not available in 3.17.

This request also includes a commit to (temporarily) set `-Wno-error=unused-result` when Github runs its compile tests. This is because the new strscpy function has a return value which is currently ignored. We should fix this upstream and then revert this second change once it is no longer needed.