### PR TITLE
Correct w8001 issue / re-enable warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,22 +30,22 @@ jobs:
             compile_cflags: -fno-pie -Wno-error=format-truncation
             prepare_cflags: -fno-pie -no-pie
           - kernel: "4.5"
-            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
+            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign
             prepare_cflags: -fno-pie -no-pie
           - kernel: "4.6"
-            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
+            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign
             prepare_cflags: -fno-pie -no-pie
           - kernel: "4.10"
-            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
+            compile_cflags: -fno-pie -Wno-error=format-truncation -Wno-error=pointer-sign
             prepare_cflags: -fno-pie -no-pie
           - kernel: "4.14"
-            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
           - kernel: "4.19"
-            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
           - kernel: "5.10"
-            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
           - kernel: "6.3"
-            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign -Wno-error=unused-result
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
             build_makeflags: KBUILD_MODPOST_WARN=1
     steps:
       - name: Install dependencies

--- a/4.5/wacom_w8001.c
+++ b/4.5/wacom_w8001.c
@@ -649,7 +649,7 @@ static int w8001_connect(struct serio *serio, struct serio_driver *drv)
 	}
 
 	if (!err_touch) {
-		snprintf(w8001->pen_name, sizeof(w8001->pen_name),
+		snprintf(w8001->touch_name, sizeof(w8001->touch_name),
 			 "%s Finger", basename);
 		input_dev_touch->name = w8001->touch_name;
 


### PR DESCRIPTION
The w8001 fix accepted upstream had an issue of its own that needed to be addressed. This pull request backports the required fix.

In addition, we revert the commit which disabled some warnings since the new code will not trigger warnings anymore.