### PR TITLE
Import wacom_wac upstream patch

### DIFF
--- a/4.18/wacom_wac.c
+++ b/4.18/wacom_wac.c
@@ -4971,6 +4971,12 @@ static const struct wacom_features wacom_features_0x94 =
 	HID_DEVICE(BUS_I2C, HID_GROUP_WACOM, USB_VENDOR_ID_WACOM, prod),\
 	.driver_data = (kernel_ulong_t)&wacom_features_##prod
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
+#define PCI_DEVICE_WACOM(prod)						\
+	HID_DEVICE(BUS_PCI, HID_GROUP_WACOM, USB_VENDOR_ID_WACOM, prod),\
+	.driver_data = (kernel_ulong_t)&wacom_features_##prod
+#endif
+
 #define USB_DEVICE_LENOVO(prod)					\
 	HID_USB_DEVICE(USB_VENDOR_ID_LENOVO, prod),			\
 	.driver_data = (kernel_ulong_t)&wacom_features_##prod
@@ -5140,6 +5146,9 @@ const struct hid_device_id wacom_ids[] = {
 
 	{ USB_DEVICE_WACOM(HID_ANY_ID) },
 	{ I2C_DEVICE_WACOM(HID_ANY_ID) },
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
+	{ PCI_DEVICE_WACOM(HID_ANY_ID) },
+#endif
 	{ BT_DEVICE_WACOM(HID_ANY_ID) },
 	{ }
 };


### PR DESCRIPTION
HID: Wacom: Add PCI Wacom device support
Add PCI device ID of wacom device into driver support list.


Tested-by: Tatsunosuke Tobita <tatsunosuke.tobita@wacom.com>
Reviewed-by: Ping Cheng <ping.cheng@wacom.com>
[tatsunosuke.tobita@wacom.com: Imported into input-wacom (c4c123504a65)]
Signed-off-by: Tatsunosuke Tobita <tatsunosuke.tobita@wacom.com>
Link: https://git.kernel.org/pub/scm/linux/kernel/git/hid/hid.git/log/?h=for-6.14/wacom-pci