### PR TITLE
Update ubuntu version in workflows

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   checkpatch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,11 +5,11 @@ permissions:
 
 env:
   COMPILE_CFLAGS: -Werror
-  PREPARE_CFLAGS:
+  PREPARE_CFLAGS: -Wno-error=use-after-free
 
 jobs:
   compile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         kernel: ["6.12", "6.10", "6.3", "5.15", "5.10", "5.4", "5.0", "4.19"]
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install gcc-9-plugin-dev libelf-dev
+          sudo apt-get install gcc-13-plugin-dev libelf-dev
           gcc -print-file-name=plugin
 
       - name: Checkout the repo
@@ -71,8 +71,14 @@ jobs:
           fi
 
           # Fix issue preventing some late-version 4.x kenels from completing config
-          if [[ "${KERNELVER}" == "4."* || "${KERNELVER}" == "5.1" ]]; then
+          if [[ "${KERNELVER}" == "4."* || "${KERNELVER}" == "5.0" ]]; then
               curl "https://github.com/torvalds/linux/commit/dfbd199a7cfe3e3cd8531e1353cdbd7175bfbc5e.patch" | patch -t -N -r - -p1 -d "${KERNELROOT}" || true
+          fi
+
+          # Fix issue preventing the 4.19 kenel and early 5.* kernels from completing config
+          if [[ "${KERNELVER}" == "4."* || "${KERNELVER}" == "5.0" || "${KERNELVER}" == "5.4" ]]; then
+              curl --output "fix.patch" "https://lore.kernel.org/lkml/20191208214607.20679-1-vt@altlinux.org/raw"
+              patch -t -N -r - -p1 -d "${KERNELROOT}" < fix.patch
           fi
 
           make -C ${KERNELROOT} defconfig


### PR DESCRIPTION
Updating the ubuntu version checkpatch and main runs on from 20.04 to 24.04 to deal with the upcoming deprecation of 20.04.