### PR TITLE
Import multiple upstream patches

### DIFF
--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -2913,7 +2913,7 @@ static void wacom_remove(struct hid_device *hdev)
 	cancel_work_sync(&wacom->battery_work);
 	cancel_work_sync(&wacom->remote_work);
 	cancel_work_sync(&wacom->mode_change_work);
-	del_timer_sync(&wacom->idleprox_timer);
+	timer_delete_sync(&wacom->idleprox_timer);
 	if (hdev->bus == BUS_BLUETOOTH)
 		device_remove_file(&hdev->dev, &dev_attr_speed);
 

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -76,9 +76,15 @@ static void wacom_wac_queue_flush(struct hid_device *hdev,
 {
 	while (!kfifo_is_empty(fifo)) {
 		int size = kfifo_peek_len(fifo);
-		u8 *buf = kzalloc(size, GFP_KERNEL);
+		u8 *buf;
 		unsigned int count;
 		int err;
+
+		buf = kzalloc(size, GFP_KERNEL);
+		if (!buf) {
+			kfifo_skip(fifo);
+			continue;
+		}
 
 		count = kfifo_out(fifo, buf, size);
 		if (count != size) {

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -2922,6 +2922,7 @@ static void wacom_remove(struct hid_device *hdev)
 	hid_hw_stop(hdev);
 
 	cancel_delayed_work_sync(&wacom->init_work);
+	cancel_delayed_work_sync(&wacom->aes_battery_work);
 	cancel_work_sync(&wacom->wireless_work);
 	cancel_work_sync(&wacom->battery_work);
 	cancel_work_sync(&wacom->remote_work);

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -93,6 +93,7 @@ static void wacom_wac_queue_flush(struct hid_device *hdev,
 			// to flush seems reasonable enough, however.
 			hid_warn(hdev, "%s: removed fifo entry with unexpected size\n",
 				 __func__);
+			kfree(buf);
 			continue;
 		}
 		err = hid_report_raw_event(hdev, HID_INPUT_REPORT, buf, size, false);

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -2076,6 +2076,7 @@ static int wacom_initialize_remotes(struct wacom *wacom)
 		hid_err(wacom->hdev,
 			"cannot create sysfs group err: %d\n", error);
 		kfifo_free(&remote->remote_fifo);
+		kobject_put(remote->remote_dir);
 		return error;
 	}
 

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -2927,7 +2927,11 @@ static void wacom_remove(struct hid_device *hdev)
 	cancel_work_sync(&wacom->battery_work);
 	cancel_work_sync(&wacom->remote_work);
 	cancel_work_sync(&wacom->mode_change_work);
+#ifdef WACOM_TIMER_DELETE_SYNC
 	timer_delete_sync(&wacom->idleprox_timer);
+#else
+	del_timer_sync(&wacom->idleprox_timer);
+#endif
 	if (hdev->bus == BUS_BLUETOOTH)
 		device_remove_file(&hdev->dev, &dev_attr_speed);
 

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -2075,6 +2075,7 @@ static int wacom_initialize_remotes(struct wacom *wacom)
 	if (error) {
 		hid_err(wacom->hdev,
 			"cannot create sysfs group err: %d\n", error);
+		kfifo_free(&remote->remote_fifo);
 		return error;
 	}
 

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -2065,8 +2065,10 @@ static int wacom_initialize_remotes(struct wacom *wacom)
 
 	remote->remote_dir = kobject_create_and_add("wacom_remote",
 						    &wacom->hdev->dev.kobj);
-	if (!remote->remote_dir)
+	if (!remote->remote_dir) {
+		kfifo_free(&remote->remote_fifo);
 		return -ENOMEM;
+	}
 
 	error = sysfs_create_files(remote->remote_dir, remote_unpair_attrs);
 

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -2385,6 +2385,8 @@ static int wacom_parse_and_register(struct wacom *wacom, bool wireless)
 	unsigned int connect_mask = HID_CONNECT_HIDRAW;
 
 	features->pktlen = wacom_compute_pktlen(hdev);
+	if (!features->pktlen)
+		return -ENODEV;
 
 	if (!devres_open_group(&hdev->dev, wacom, GFP_KERNEL))
 		return -ENOMEM;

--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,22 @@ WACOM_LINUX_TRY_COMPILE([
 	AC_MSG_RESULT([no])
 ])
 
+dnl Check if del_timer_sync has been renamed to timer_delete_sync or
+dnl not. This is the case in Linux 6.1.84 and later.
+AC_MSG_CHECKING(timer_delete_sync)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/timer.h>
+bool timer_delete_sync(struct timer_list *timer) { return true; }
+],[
+],[
+	HAVE_TIMER_DELETE_SYNC=no
+	AC_MSG_RESULT([no])
+],[
+	HAVE_TIMER_DELETE_SYNC=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_TIMER_DELETE_SYNC], [], [kernel defines timer_delete_sync from v6.1.84+])
+])
+
 
 
 dnl Check which version of the driver we should compile


### PR DESCRIPTION
Importing multiple upstream patches that cover:

- Handling the rename of del_timer_sync to timer_delete_sync
- Various Memory Leak and Allocation fixes
- Fixing a crash that was caused in wacom_aes_battery_handler

As well as adding a new flag to configure.ac (WACOM_TIMER_DELETE_SYNC) for use in wacom_sys.c to handle kernel versions before the rename (<6.1.84) and ensure it compiles correctly on those systems.