### PR TITLE
Import wacom_wac upstream patches

### DIFF
--- a/4.18/wacom_wac.c
+++ b/4.18/wacom_wac.c
@@ -75,7 +75,7 @@ static void wacom_force_proxout(struct wacom_wac *wacom_wac)
 
 void wacom_idleprox_timeout(struct timer_list *list)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,16,0)	
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,16,0)
 	struct wacom *wacom = from_timer(wacom, list, idleprox_timer);
 #else
 	struct wacom *wacom = timer_container_of(wacom, list, idleprox_timer);

--- a/4.18/wacom_wac.c
+++ b/4.18/wacom_wac.c
@@ -75,7 +75,11 @@ static void wacom_force_proxout(struct wacom_wac *wacom_wac)
 
 void wacom_idleprox_timeout(struct timer_list *list)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,16,0)	
 	struct wacom *wacom = from_timer(wacom, list, idleprox_timer);
+#else
+	struct wacom *wacom = timer_container_of(wacom, list, idleprox_timer);
+#endif
 	struct wacom_wac *wacom_wac = &wacom->wacom_wac;
 
 	if (!wacom_wac->hid_data.sense_state) {

--- a/4.18/wacom_wac.c
+++ b/4.18/wacom_wac.c
@@ -700,6 +700,7 @@ static bool wacom_is_art_pen(int tool_id)
 	case 0x885:	/* Intuos3 Marker Pen */
 	case 0x804:	/* Intuos4/5 13HD/24HD Marker Pen */
 	case 0x10804:	/* Intuos4/5 13HD/24HD Art Pen */
+	case 0x204:     /* Art Pen 2 */
 		is_art_pen = true;
 		break;
 	}


### PR DESCRIPTION
treewide, timers: Rename from_timer() to timer_container_of()
Move this API to the canonical timer_*() namespace.

[ tglx: Redone against pre rc1 ]

Signed-off-by: Ingo Molnar <mingo@kernel.org>
Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
Link: https://lore.kernel.org/all/aB2X0jCKQO56WdMt@gmail.com
[tatsunosuke.tobita@wacom.com: Imported into input-wacom (41cb08555c41)]
Signed-off-by: Tatsunosuke Tobita <tatsunosuke.tobita@wacom.com>
Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/hid/wacom_wac.c?h=v6.18-rc4&id=41cb08555c4164996d67c78b3bf1c658075b75f1