### PR TITLE
Import the patch applied as (41cb08555c41) and the change for configure.ac to apply it to appropriate kernel versions

### DIFF
--- a/4.18/wacom_wac.c
+++ b/4.18/wacom_wac.c
@@ -75,7 +75,11 @@ static void wacom_force_proxout(struct wacom_wac *wacom_wac)
 
 void wacom_idleprox_timeout(struct timer_list *list)
 {
+#ifdef WACOM_TIMER_ADDR_CONTAINER_RENAME
+	struct wacom *wacom = timer_container_of(wacom, list, idleprox_timer);
+#else
 	struct wacom *wacom = from_timer(wacom, list, idleprox_timer);
+#endif
 	struct wacom_wac *wacom_wac = &wacom->wacom_wac;
 
 	if (!wacom_wac->hid_data.sense_state) {

--- a/configure.ac
+++ b/configure.ac
@@ -303,7 +303,21 @@ bool timer_delete_sync(struct timer_list *timer) { return true; }
 	AC_DEFINE([WACOM_TIMER_DELETE_SYNC], [], [kernel defines timer_delete_sync from v6.1.84+])
 ])
 
-
+dnl Check if from_timer has been renamed to timer_container_of or
+dnl not. This is the case in Linux 6.16 and later.
+AC_MSG_CHECKING(timer_container_of)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/timer.h>
+bool timer_container_of() { return true; }
+],[
+],[
+	HAVE_TIMER_CONTAINER_OF=no
+	AC_MSG_RESULT([no])
+],[
+	HAVE_TIMER_CONTAINER_OF=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_TIMER_ADDR_CONTAINER_RENAME], [], [kernel defines timer_container_of from v6.16])
+])
 
 dnl Check which version of the driver we should compile
 AC_DEFUN([WCM_EXPLODE], [$(echo "$1" | awk '{split($[0],x,"[[^0-9]]"); printf("%03d%03d%03d\n",x[[1]],x[[2]],x[[3]]);}')])

--- a/configure.ac
+++ b/configure.ac
@@ -308,15 +308,17 @@ dnl not. This is the case in Linux 6.16 and later.
 AC_MSG_CHECKING(timer_container_of)
 WACOM_LINUX_TRY_COMPILE([
 #include <linux/timer.h>
-bool timer_container_of() { return true; }
+#ifndef timer_container_of
+#error "timer_container_of is not defined"
+#endif
 ],[
-],[
-	HAVE_TIMER_CONTAINER_OF=no
-	AC_MSG_RESULT([no])
 ],[
 	HAVE_TIMER_CONTAINER_OF=yes
 	AC_MSG_RESULT([yes])
 	AC_DEFINE([WACOM_TIMER_ADDR_CONTAINER_RENAME], [], [kernel defines timer_container_of from v6.16])
+],[
+	HAVE_TIMER_CONTAINER_OF=no
+	AC_MSG_RESULT([no])
 ])
 
 dnl Check which version of the driver we should compile


### PR DESCRIPTION
treewide, timers: Rename from_timer() to timer_container_of()

Move this API to the canonical timer_*() namespace.

[ tglx: Redone against pre rc1 ]

Signed-off-by: Ingo Molnar mingo@kernel.org
Signed-off-by: Thomas Gleixner tglx@linutronix.de
Link: https://lore.kernel.org/all/aB2X0jCKQO56WdMt@gmail.com
[tatsunosuke.tobita@wacom.com: Imported into input-wacom (41cb08555c41)]
Signed-off-by: Tatsunosuke Tobita <tatsunosuke.tobita@wacom.com>
Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/hid/wacom_wac.c?h=v6.18-rc4&id=41cb08555c4164996d67c78b3bf1c658075b75f1
