### PR TITLE
Import an upstream patch (2f1763f62909)

### DIFF
--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -2942,7 +2942,9 @@ static void wacom_remove(struct hid_device *hdev)
 		wacom_release_resources(wacom);
 }
 
+#ifndef HAVE_PM_PTR
 #ifdef CONFIG_PM
+#endif
 static int wacom_resume(struct hid_device *hdev)
 {
 	struct wacom *wacom = hid_get_drvdata(hdev);
@@ -2962,7 +2964,9 @@ static int wacom_reset_resume(struct hid_device *hdev)
 {
 	return wacom_resume(hdev);
 }
+#ifndef HAVE_PM_PTR
 #endif /* CONFIG_PM */
+#endif
 
 static struct hid_driver wacom_driver = {
 	.name =		"wacom",
@@ -2970,10 +2974,15 @@ static struct hid_driver wacom_driver = {
 	.probe =	wacom_probe,
 	.remove =	wacom_remove,
 	.report =	wacom_wac_report,
+#ifdef HAVE_PM_PTR
+	.resume =	pm_ptr(wacom_resume),
+	.reset_resume =	pm_ptr(wacom_reset_resume),
+#else
 #ifdef CONFIG_PM
 	.resume =	wacom_resume,
 	.reset_resume =	wacom_reset_resume,
 #endif
+#endif	
 	.raw_event =	wacom_raw_event,
 };
 module_hid_driver(wacom_driver);

--- a/4.18/wacom_wac.c
+++ b/4.18/wacom_wac.c
@@ -1224,10 +1224,20 @@ static int wacom_intuos_bt_irq(struct wacom_wac *wacom, size_t len)
 
 	switch (data[0]) {
 	case 0x04:
+		if (len < 32) {
+			dev_warn(wacom->pen_input->dev.parent,
+				 "Report 0x04 too short: %zu bytes\n", len);
+			break;
+		}
 		wacom_intuos_bt_process_data(wacom, data + i);
 		i += 10;
 		fallthrough;
 	case 0x03:
+		if (i == 1 && len < 22) {
+			dev_warn(wacom->pen_input->dev.parent,
+				 "Report 0x03 too short: %zu bytes\n", len);
+			break;
+		}
 		wacom_intuos_bt_process_data(wacom, data + i);
 		i += 10;
 		wacom_intuos_bt_process_data(wacom, data + i);

--- a/configure.ac
+++ b/configure.ac
@@ -321,6 +321,24 @@ WACOM_LINUX_TRY_COMPILE([
 	AC_MSG_RESULT([no])
 ])
 
+dnl Check if pm_ptr has been added to pm.h or
+dnl not. This is the case in Linux 5.9 and later.
+AC_MSG_CHECKING(pm_ptr)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/pm.h>
+#ifndef pm_ptr
+#error "pm_ptr is not defined"
+#endif
+],[
+],[
+	HAVE_PM_PTR=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_PM_PTR], [], [kernel defines pm_ptr from v5.9])
+],[
+	HAVE_PM_PTR=no
+	AC_MSG_RESULT([no])
+])
+
 dnl Check which version of the driver we should compile
 AC_DEFUN([WCM_EXPLODE], [$(echo "$1" | awk '{split($[0],x,"[[^0-9]]"); printf("%03d%03d%03d\n",x[[1]],x[[2]],x[[3]]);}')])
 EXPLODED_VER="WCM_EXPLODE($MODUTS)"


### PR DESCRIPTION
HID: wacom: fix out-of-bounds read in wacom_intuos_bt_irq

The wacom_intuos_bt_irq() function processes Bluetooth HID reports without sufficient bounds checking. A maliciously crafted short report can trigger an out-of-bounds read when copying data into the wacom structure.

Specifically, report 0x03 requires at least 22 bytes to safely read the processed data and battery status, while report 0x04 (which falls through to 0x03) requires 32 bytes.

Add explicit length checks for these report IDs and log a warning if a short report is received.

Reviewed-by: Jason Gerecke <jason.gerecke@wacom.com>
[tatsunosuke.tobita@wacom.com: Imported into input-wacom (2f1763f62909)]
Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/hid/wacom_wac.c?h=v7.0-rc6&id=2f1763f62909ccb6386ac50350fa0abbf5bb16a9