### PR TITLE
Import upstream patch(2f1763f62909)

### DIFF
--- a/4.18/wacom_wac.c
+++ b/4.18/wacom_wac.c
@@ -1224,10 +1224,20 @@ static int wacom_intuos_bt_irq(struct wacom_wac *wacom, size_t len)
 
 	switch (data[0]) {
 	case 0x04:
+		if (len < 32) {
+			dev_warn(wacom->pen_input->dev.parent,
+				 "Report 0x04 too short: %zu bytes\n", len);
+			break;
+		}
 		wacom_intuos_bt_process_data(wacom, data + i);
 		i += 10;
 		fallthrough;
 	case 0x03:
+		if (i == 1 && len < 22) {
+			dev_warn(wacom->pen_input->dev.parent,
+				 "Report 0x03 too short: %zu bytes\n", len);
+			break;
+		}
 		wacom_intuos_bt_process_data(wacom, data + i);
 		i += 10;
 		wacom_intuos_bt_process_data(wacom, data + i);


### PR DESCRIPTION
HID: wacom: fix out-of-bounds read in wacom_intuos_bt_irq

The wacom_intuos_bt_irq() function processes Bluetooth HID reports without sufficient bounds checking. A maliciously crafted short report can trigger an out-of-bounds read when copying data into the wacom structure.
Specifically, report 0x03 requires at least 22 bytes to safely read the processed data and battery status, while report 0x04 (which falls through to 0x03) requires 32 bytes.
Add explicit length checks for these report IDs and log a warning if a short report is received.

Reviewed-by: Jason Gerecke <jason.gerecke@wacom.com>
[tatsunosuke.tobita@wacom.com: Imported into input-wacom (2f1763f62909)]
Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/hid/wacom_wac.c?h=v7.0-rc6&id=2f1763f62909ccb6386ac50350fa0abbf5bb16a9