### PR TITLE
Replace pm comfig

### DIFF
--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -2942,7 +2942,9 @@ static void wacom_remove(struct hid_device *hdev)
 		wacom_release_resources(wacom);
 }
 
+#ifndef HAVE_PM_PTR
 #ifdef CONFIG_PM
+#endif
 static int wacom_resume(struct hid_device *hdev)
 {
 	struct wacom *wacom = hid_get_drvdata(hdev);
@@ -2962,7 +2964,9 @@ static int wacom_reset_resume(struct hid_device *hdev)
 {
 	return wacom_resume(hdev);
 }
+#ifndef HAVE_PM_PTR
 #endif /* CONFIG_PM */
+#endif
 
 static struct hid_driver wacom_driver = {
 	.name =		"wacom",
@@ -2970,9 +2974,14 @@ static struct hid_driver wacom_driver = {
 	.probe =	wacom_probe,
 	.remove =	wacom_remove,
 	.report =	wacom_wac_report,
+#ifdef HAVE_PM_PTR
+	.resume =	pm_ptr(wacom_resume),
+	.reset_resume =	pm_ptr(wacom_reset_resume),
+#else
 #ifdef CONFIG_PM
 	.resume =	wacom_resume,
 	.reset_resume =	wacom_reset_resume,
+#endif
 #endif
 	.raw_event =	wacom_raw_event,
 };

--- a/configure.ac
+++ b/configure.ac
@@ -321,6 +321,24 @@ WACOM_LINUX_TRY_COMPILE([
 	AC_MSG_RESULT([no])
 ])
 
+dnl Check if pm_ptr has been added to pm.h or
+dnl not. This is the case in Linux 5.9 and later.
+AC_MSG_CHECKING(pm_ptr)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/pm.h>
+#ifndef pm_ptr
+#error "pm_ptr is not defined"
+#endif
+],[
+],[
+	HAVE_PM_PTR=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_PM_PTR], [], [kernel defines pm_ptr from v5.9])
+],[
+	HAVE_PM_PTR=no
+	AC_MSG_RESULT([no])
+])
+
 dnl Check which version of the driver we should compile
 AC_DEFUN([WCM_EXPLODE], [$(echo "$1" | awk '{split($[0],x,"[[^0-9]]"); printf("%03d%03d%03d\n",x[[1]],x[[2]],x[[3]]);}')])
 EXPLODED_VER="WCM_EXPLODE($MODUTS)"


### PR DESCRIPTION
There are multiple changes on this PR.

- Backport the commit of "HID: wacom: Use pm_ptr instead of #ifdef CONFIG_PM
" (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/hid/wacom_sys.c?id=a864d16be15625df365a5945f566efc2e36f73c3)
- Modification on configure.ac in order to apply the change above appropriately by checking the availability of the function

Signed-off-by: Tatsunosuke Tobita [tatsunosuke.tobita@wacom.com](mailto:tatsunosuke.tobita@wacom.com)