### PR TITLE
4.18: fix hid_report_raw_event arguments for kernel 7.0.8+

### DIFF
--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -96,7 +96,7 @@ static void wacom_wac_queue_flush(struct hid_device *hdev,
 			kfree(buf);
 			continue;
 		}
-		err = hid_report_raw_event(hdev, HID_INPUT_REPORT, buf, size, false);
+		err = hid_report_raw_event(hdev, HID_INPUT_REPORT, buf, size, size, false);
 		if (err) {
 			hid_warn(hdev, "%s: unable to flush event due to error %d\n",
 				 __func__, err);
@@ -340,7 +340,7 @@ static void wacom_feature_mapping(struct hid_device *hdev,
 					       data, n, WAC_CMD_RETRIES);
 			if (ret == n && features->type == HID_GENERIC) {
 				ret = hid_report_raw_event(hdev,
-					HID_FEATURE_REPORT, data, n, 0);
+					HID_FEATURE_REPORT, data, n, n, 0);
 			} else if (ret == 2 && features->type != HID_GENERIC) {
 				features->touch_max = data[1];
 			} else {
@@ -401,7 +401,7 @@ static void wacom_feature_mapping(struct hid_device *hdev,
 					data, n, WAC_CMD_RETRIES);
 		if (ret == n) {
 			ret = hid_report_raw_event(hdev, HID_FEATURE_REPORT,
-						   data, n, 0);
+						   data, n, n, 0);
 		} else {
 			hid_warn(hdev, "%s: could not retrieve sensor offsets\n",
 				 __func__);

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -96,7 +96,11 @@ static void wacom_wac_queue_flush(struct hid_device *hdev,
 			kfree(buf);
 			continue;
 		}
+#ifdef WACOM_HID_REPORT_RAW_EVENT_BUFSIZE
 		err = hid_report_raw_event(hdev, HID_INPUT_REPORT, buf, size, size, false);
+#else
+		err = hid_report_raw_event(hdev, HID_INPUT_REPORT, buf, size, false);
+#endif
 		if (err) {
 			hid_warn(hdev, "%s: unable to flush event due to error %d\n",
 				 __func__, err);
@@ -339,8 +343,13 @@ static void wacom_feature_mapping(struct hid_device *hdev,
 			ret = wacom_get_report(hdev, HID_FEATURE_REPORT,
 					       data, n, WAC_CMD_RETRIES);
 			if (ret == n && features->type == HID_GENERIC) {
+#ifdef WACOM_HID_REPORT_RAW_EVENT_BUFSIZE
 				ret = hid_report_raw_event(hdev,
 					HID_FEATURE_REPORT, data, n, n, 0);
+#else
+				ret = hid_report_raw_event(hdev,
+					HID_FEATURE_REPORT, data, n, 0);
+#endif
 			} else if (ret == 2 && features->type != HID_GENERIC) {
 				features->touch_max = data[1];
 			} else {
@@ -400,8 +409,13 @@ static void wacom_feature_mapping(struct hid_device *hdev,
 		ret = wacom_get_report(hdev, HID_FEATURE_REPORT,
 					data, n, WAC_CMD_RETRIES);
 		if (ret == n) {
+#ifdef WACOM_HID_REPORT_RAW_EVENT_BUFSIZE
 			ret = hid_report_raw_event(hdev, HID_FEATURE_REPORT,
 						   data, n, n, 0);
+#else
+			ret = hid_report_raw_event(hdev, HID_FEATURE_REPORT,
+						   data, n, 0);
+#endif
 		} else {
 			hid_warn(hdev, "%s: could not retrieve sensor offsets\n",
 				 __func__);

--- a/configure.ac
+++ b/configure.ac
@@ -303,6 +303,35 @@ bool timer_delete_sync(struct timer_list *timer) { return true; }
 	AC_DEFINE([WACOM_TIMER_DELETE_SYNC], [], [kernel defines timer_delete_sync from v6.1.84+])
 ])
 
+
+dnl Check if hid_report_raw_event takes a bufsize parameter or not.
+dnl This is the case in Linux 7.0.8 and later.
+AC_MSG_CHECKING(hid_report_raw_event bufsize parameter)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/hid.h>
+static int (*test_fn)(
+        struct hid_device *,
+        enum hid_report_type,
+        u8 *,
+        size_t,
+        u32,
+        int
+) = hid_report_raw_event;
+int test(void)
+{
+        return test_fn != NULL;
+}
+],[
+],[
+        HAVE_HID_REPORT_RAW_EVENT_BUFSIZE=yes
+        AC_MSG_RESULT([yes])
+        AC_DEFINE([WACOM_HID_REPORT_RAW_EVENT_BUFSIZE], [],
+                  [kernel hid_report_raw_event() takes a bufsize parameter])
+],[
+        HAVE_HID_REPORT_RAW_EVENT_BUFSIZE=no
+        AC_MSG_RESULT([no])
+])
+
 dnl Check if from_timer has been renamed to timer_container_of or
 dnl not. This is the case in Linux 6.16 and later.
 AC_MSG_CHECKING(timer_container_of)


### PR DESCRIPTION
The `hid_report_raw_event()` API changed in upstream commit `2c85c61d1332` ("HID: pass the buffer size to hid_report_raw_event"), adding a `bufsize` parameter to the function signature.

To maintain compatibility across kernels with both API variants, this patch adds a configure-time feature check using `WACOM_LINUX_TRY_COMPILE`. When the newer signature is detected, `WACOM_HID_REPORT_RAW_EVENT_BUFSIZE` is defined in `config.h`.

The driver code in `4.18/wacom_sys.c` uses this macro to select the appropriate `hid_report_raw_event()` call signature at compile time, preserving compatibility with both older and newer kernels.

#### Problem / Error Log

When building against kernels that include the updated `hid_report_raw_event()` signature, compilation fails due to the missing `bufsize` argument:

```text
error: too few arguments to function 'hid_report_raw_event'
  ... | err = hid_report_raw_event(hdev, HID_INPUT_REPORT, buf, size, false);
```

#### How has this been tested?

* **New API path (`WACOM_HID_REPORT_RAW_EVENT_BUFSIZE` defined):**
  Successfully configured, compiled, and tested on EndeavourOS with Linux `7.0.11-zen1-1-zen`. The driver builds correctly and hardware functionality was verified using a Wacom Intuos CTH-480.

* **Legacy API path (`WACOM_HID_REPORT_RAW_EVENT_BUFSIZE` undefined):**
  Successfully configured and compiled against Ubuntu 22.04 Linux `5.15.0-107-generic` kernel headers. The feature detection correctly selected the legacy 5-argument signature and the driver built without errors.
