### PR TITLE
Backports for Input Wacom 1.7.0 Release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           gcc -print-file-name=plugin
 
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download and extract v${{ matrix.kernel }} kernel
         run: |
@@ -97,7 +97,7 @@ jobs:
 
       - name: Save build directory as artifact
         if: '!cancelled()'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: input-wacom-${{ matrix.kernel }}
           retention-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        kernel: ["7.0", "6.12", "6.10", "6.3", "5.15", "5.10", "5.4", "5.0", "4.19"]
+        kernel: ["7.0", "6.17", "6.12", "6.10", "6.5", "6.3", "5.17", "5.15", "5.10", "5.4", "5.0", "4.19"]
         include:
           - kernel: "4.19"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
@@ -24,13 +24,21 @@ jobs:
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
           - kernel: "5.15"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+          - kernel: "5.17"
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
           - kernel: "6.3"
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+            build_makeflags: KBUILD_MODPOST_WARN=1
+          - kernel: "6.5"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
             build_makeflags: KBUILD_MODPOST_WARN=1
           - kernel: "6.10"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
             build_makeflags: KBUILD_MODPOST_WARN=1
           - kernel: "6.12"
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+            build_makeflags: KBUILD_MODPOST_WARN=1
+          - kernel: "6.17"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
             build_makeflags: KBUILD_MODPOST_WARN=1
           - kernel: "7.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        kernel: ["6.12", "6.10", "6.3", "5.15", "5.10", "5.4", "5.0", "4.19"]
+        kernel: ["7.0", "6.12", "6.10", "6.3", "5.15", "5.10", "5.4", "5.0", "4.19"]
         include:
           - kernel: "4.19"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
@@ -31,6 +31,9 @@ jobs:
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
             build_makeflags: KBUILD_MODPOST_WARN=1
           - kernel: "6.12"
+            compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
+            build_makeflags: KBUILD_MODPOST_WARN=1
+          - kernel: "7.0"
             compile_cflags: -Wno-error=format-truncation -Wno-error=pointer-sign
             build_makeflags: KBUILD_MODPOST_WARN=1
     steps:

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       # ...
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           fetch-tags: 'true'

--- a/4.18/wacom_i2c.c
+++ b/4.18/wacom_i2c.c
@@ -338,7 +338,7 @@ static int wacom_i2c_probe(struct i2c_client *client)
 	return 0;
 }
 
-static int __maybe_unused wacom_i2c_suspend(struct device *dev)
+static int wacom_i2c_suspend(struct device *dev)
 {
 	struct i2c_client *client = to_i2c_client(dev);
 
@@ -347,7 +347,7 @@ static int __maybe_unused wacom_i2c_suspend(struct device *dev)
 	return 0;
 }
 
-static int __maybe_unused wacom_i2c_resume(struct device *dev)
+static int wacom_i2c_resume(struct device *dev)
 {
 	struct i2c_client *client = to_i2c_client(dev);
 
@@ -356,7 +356,7 @@ static int __maybe_unused wacom_i2c_resume(struct device *dev)
 	return 0;
 }
 
-static SIMPLE_DEV_PM_OPS(wacom_i2c_pm, wacom_i2c_suspend, wacom_i2c_resume);
+static DEFINE_SIMPLE_DEV_PM_OPS(wacom_i2c_pm, wacom_i2c_suspend, wacom_i2c_resume);
 
 static const struct i2c_device_id wacom_i2c_id[] = {
 	{ "WAC_I2C_EMR", 0 },
@@ -375,7 +375,7 @@ MODULE_DEVICE_TABLE(of, wacom_i2c_of_match_table);
 static struct i2c_driver wacom_i2c_driver = {
 	.driver	= {
 		.name	= "wacom_i2c",
-		.pm	= &wacom_i2c_pm,
+		.pm	= pm_sleep_ptr(&wacom_i2c_pm),
 
 #ifdef CONFIG_OF
 		.of_match_table = of_match_ptr(wacom_i2c_of_match_table),

--- a/4.18/wacom_i2c.c
+++ b/4.18/wacom_i2c.c
@@ -359,8 +359,8 @@ static int wacom_i2c_resume(struct device *dev)
 static DEFINE_SIMPLE_DEV_PM_OPS(wacom_i2c_pm, wacom_i2c_suspend, wacom_i2c_resume);
 
 static const struct i2c_device_id wacom_i2c_id[] = {
-	{ "WAC_I2C_EMR", 0 },
-	{ },
+	{ "WAC_I2C_EMR" },
+	{ }
 };
 MODULE_DEVICE_TABLE(i2c, wacom_i2c_id);
 

--- a/4.18/wacom_i2c.c
+++ b/4.18/wacom_i2c.c
@@ -338,7 +338,11 @@ static int wacom_i2c_probe(struct i2c_client *client)
 	return 0;
 }
 
+#ifdef WACOM_DEFINE_SIMPLE_DEV_PM_OPS
 static int wacom_i2c_suspend(struct device *dev)
+#else
+static int __maybe_unused wacom_i2c_suspend(struct device *dev)
+#endif
 {
 	struct i2c_client *client = to_i2c_client(dev);
 
@@ -347,7 +351,11 @@ static int wacom_i2c_suspend(struct device *dev)
 	return 0;
 }
 
+#ifdef WACOM_DEFINE_SIMPLE_DEV_PM_OPS
 static int wacom_i2c_resume(struct device *dev)
+#else
+static int __maybe_unused wacom_i2c_resume(struct device *dev)
+#endif
 {
 	struct i2c_client *client = to_i2c_client(dev);
 
@@ -356,7 +364,11 @@ static int wacom_i2c_resume(struct device *dev)
 	return 0;
 }
 
+#ifdef WACOM_DEFINE_SIMPLE_DEV_PM_OPS
 static DEFINE_SIMPLE_DEV_PM_OPS(wacom_i2c_pm, wacom_i2c_suspend, wacom_i2c_resume);
+#else
+static SIMPLE_DEV_PM_OPS(wacom_i2c_pm, wacom_i2c_suspend, wacom_i2c_resume);
+#endif
 
 static const struct i2c_device_id wacom_i2c_id[] = {
 	{ "WAC_I2C_EMR" },
@@ -375,7 +387,11 @@ MODULE_DEVICE_TABLE(of, wacom_i2c_of_match_table);
 static struct i2c_driver wacom_i2c_driver = {
 	.driver	= {
 		.name	= "wacom_i2c",
+#ifdef WACOM_DEFINE_SIMPLE_DEV_PM_OPS
 		.pm	= pm_sleep_ptr(&wacom_i2c_pm),
+#else
+		.pm = &wacom_i2c_pm,
+#endif
 
 #ifdef CONFIG_OF
 		.of_match_table = of_match_ptr(wacom_i2c_of_match_table),

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -60,7 +60,7 @@ static void wacom_wac_queue_insert(struct hid_device *hdev,
 {
 	bool warned = false;
 
-	while (kfifo_avail(fifo) < size) {
+	while (kfifo_avail(fifo) < size && !kfifo_is_empty(fifo)) {
 		if (!warned)
 			hid_warn(hdev, "%s: kfifo has filled, starting to drop events\n", __func__);
 		warned = true;
@@ -68,7 +68,9 @@ static void wacom_wac_queue_insert(struct hid_device *hdev,
 		kfifo_skip(fifo);
 	}
 
-	kfifo_in(fifo, raw_data, size);
+	if (!kfifo_in(fifo, raw_data, size))
+		hid_warn_ratelimited(hdev, "%s: report is too large (%d)\n",
+				     __func__, size);
 }
 
 static void wacom_wac_queue_flush(struct hid_device *hdev,

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -934,7 +934,7 @@ static int wacom_add_shared_data(struct hid_device *hdev)
 
 	data = wacom_get_hdev_data(hdev);
 	if (!data) {
-		data = kzalloc(sizeof(struct wacom_hdev_data), GFP_KERNEL);
+		data = kzalloc_obj(struct wacom_hdev_data, GFP_KERNEL);
 		if (!data) {
 			mutex_unlock(&wacom_udev_list_lock);
 			return -ENOMEM;

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -371,6 +371,7 @@ static void wacom_feature_mapping(struct hid_device *hdev,
 
 		hid_data->inputmode = field->report->id;
 		hid_data->inputmode_index = usage->usage_index;
+		hid_data->inputmode_field_index = field->index;
 		break;
 
 	case HID_UP_DIGITIZER:
@@ -591,9 +592,14 @@ static int wacom_hid_set_device_mode(struct hid_device *hdev)
 
 	re = &(hdev->report_enum[HID_FEATURE_REPORT]);
 	r = re->report_id_hash[hid_data->inputmode];
-	if (r) {
-		r->field[0]->value[hid_data->inputmode_index] = 2;
-		hid_hw_request(hdev, r, HID_REQ_SET_REPORT);
+	if (r && hid_data->inputmode_field_index >= 0 &&
+		hid_data->inputmode_field_index < r->maxfield) {
+		struct hid_field *field = r->field[hid_data->inputmode_field_index];
+
+		if (field && hid_data->inputmode_index < field->report_count) {
+			field->value[hid_data->inputmode_index] = 2;
+			hid_hw_request(hdev, r, HID_REQ_SET_REPORT);
+		}
 	}
 	return 0;
 }
@@ -2877,6 +2883,7 @@ static int wacom_probe(struct hid_device *hdev,
 		return -ENODEV;
 
 	wacom_wac->hid_data.inputmode = -1;
+	wacom_wac->hid_data.inputmode_field_index = -1;
 	wacom_wac->mode_report = -1;
 
 	if (wacom_is_using_usb_driver(hdev)) {

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -78,11 +78,10 @@ static void wacom_wac_queue_flush(struct hid_device *hdev,
 {
 	while (!kfifo_is_empty(fifo)) {
 		int size = kfifo_peek_len(fifo);
-		u8 *buf;
+		u8 *buf __free(kfree) = kzalloc(size, GFP_ATOMIC);
 		unsigned int count;
 		int err;
 
-		buf = kzalloc(size, GFP_ATOMIC);
 		if (!buf) {
 			kfifo_skip(fifo);
 			continue;
@@ -94,8 +93,7 @@ static void wacom_wac_queue_flush(struct hid_device *hdev,
 			// circumstance. Skipping the entry and continuing
 			// to flush seems reasonable enough, however.
 			hid_warn(hdev, "%s: removed fifo entry with unexpected size\n",
-				 __func__);
-			kfree(buf);
+				 __func__);\
 			continue;
 		}
 #ifdef WACOM_HID_REPORT_RAW_EVENT_BUFSIZE
@@ -107,8 +105,6 @@ static void wacom_wac_queue_flush(struct hid_device *hdev,
 			hid_warn(hdev, "%s: unable to flush event due to error %d\n",
 				 __func__, err);
 		}
-
-		kfree(buf);
 	}
 }
 

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -2495,16 +2495,16 @@ static int wacom_parse_and_register(struct wacom *wacom, bool wireless)
 
 	error = wacom_register_inputs(wacom);
 	if (error)
-		goto fail;
+		goto fail_hw_stop;
 
 	if (wacom->wacom_wac.features.device_type & WACOM_DEVICETYPE_PAD) {
 		error = wacom_initialize_leds(wacom);
 		if (error)
-			goto fail;
+			goto fail_hw_stop;
 
 		error = wacom_initialize_remotes(wacom);
 		if (error)
-			goto fail;
+			goto fail_hw_stop;
 	}
 
 	if (!wireless) {
@@ -2518,14 +2518,14 @@ static int wacom_parse_and_register(struct wacom *wacom, bool wireless)
 		cancel_delayed_work_sync(&wacom->init_work);
 		_wacom_query_tablet_data(wacom);
 		error = -ENODEV;
-		goto fail_quirks;
+		goto fail_hw_stop;
 	}
 
 	if (features->device_type & WACOM_DEVICETYPE_WL_MONITOR) {
 		error = hid_hw_open(hdev);
 		if (error) {
 			hid_err(hdev, "hw open failed\n");
-			goto fail_quirks;
+			goto fail_hw_stop;
 		}
 	}
 
@@ -2534,7 +2534,7 @@ static int wacom_parse_and_register(struct wacom *wacom, bool wireless)
 
 	return 0;
 
-fail_quirks:
+fail_hw_stop:
 	hid_hw_stop(hdev);
 fail:
 	wacom_release_resources(wacom);

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -68,9 +68,13 @@ static void wacom_wac_queue_insert(struct hid_device *hdev,
 		kfifo_skip(fifo);
 	}
 
+#ifdef WACOM_HID_WARN_RATELIMITED
 	if (!kfifo_in(fifo, raw_data, size))
 		hid_warn_ratelimited(hdev, "%s: report is too large (%d)\n",
 				     __func__, size);
+#else
+	kfifo_in(fifo, raw_data, size);
+#endif
 }
 
 static void wacom_wac_queue_flush(struct hid_device *hdev,
@@ -78,9 +82,18 @@ static void wacom_wac_queue_flush(struct hid_device *hdev,
 {
 	while (!kfifo_is_empty(fifo)) {
 		int size = kfifo_peek_len(fifo);
+#ifdef WACOM_CLEANUP_FREE
 		u8 *buf __free(kfree) = kzalloc(size, GFP_ATOMIC);
+#else
+		u8 *buf;
+#endif
 		unsigned int count;
 		int err;
+
+#ifdef WACOM_CLEANUP_FREE
+#else
+		buf = kzalloc(size, GFP_ATOMIC);
+#endif
 
 		if (!buf) {
 			kfifo_skip(fifo);
@@ -92,8 +105,12 @@ static void wacom_wac_queue_flush(struct hid_device *hdev,
 			// Hard to say what is the "right" action in this
 			// circumstance. Skipping the entry and continuing
 			// to flush seems reasonable enough, however.
-			hid_warn(hdev, "%s: removed fifo entry with unexpected size\n",
-				 __func__);\
+		hid_warn(hdev, "%s: removed fifo entry with unexpected size\n",
+				 __func__);
+#ifdef WACOM_CLEANUP_FREE
+#else
+			kfree(buf);
+#endif
 			continue;
 		}
 #ifdef WACOM_HID_REPORT_RAW_EVENT_BUFSIZE
@@ -105,6 +122,10 @@ static void wacom_wac_queue_flush(struct hid_device *hdev,
 			hid_warn(hdev, "%s: unable to flush event due to error %d\n",
 				 __func__, err);
 		}
+#ifdef WACOM_CLEANUP_FREE
+#else
+		kfree(buf);
+#endif
 	}
 }
 

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -82,7 +82,7 @@ static void wacom_wac_queue_flush(struct hid_device *hdev,
 		unsigned int count;
 		int err;
 
-		buf = kzalloc(size, GFP_KERNEL);
+		buf = kzalloc(size, GFP_ATOMIC);
 		if (!buf) {
 			kfifo_skip(fifo);
 			continue;

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -934,7 +934,7 @@ static int wacom_add_shared_data(struct hid_device *hdev)
 
 	data = wacom_get_hdev_data(hdev);
 	if (!data) {
-		data = kzalloc_obj(struct wacom_hdev_data, GFP_KERNEL);
+		data = kzalloc_obj(struct wacom_hdev_data);
 		if (!data) {
 			mutex_unlock(&wacom_udev_list_lock);
 			return -ENOMEM;

--- a/4.18/wacom_sys.c
+++ b/4.18/wacom_sys.c
@@ -934,7 +934,11 @@ static int wacom_add_shared_data(struct hid_device *hdev)
 
 	data = wacom_get_hdev_data(hdev);
 	if (!data) {
+#ifdef WACOM_KZALLOC_OBJ
 		data = kzalloc_obj(struct wacom_hdev_data);
+#else
+		data = kzalloc(sizeof(struct wacom_hdev_data), GFP_KERNEL);
+#endif
 		if (!data) {
 			mutex_unlock(&wacom_udev_list_lock);
 			return -ENOMEM;

--- a/4.18/wacom_w8001.c
+++ b/4.18/wacom_w8001.c
@@ -596,7 +596,7 @@ static int w8001_connect(struct serio *serio, struct serio_driver *drv)
 	char basename[64] = "Wacom Serial";
 	int err, err_pen, err_touch;
 
-	w8001 = kzalloc_obj(*w8001, GFP_KERNEL);
+	w8001 = kzalloc_obj(*w8001);
 	input_dev_pen = input_allocate_device();
 	input_dev_touch = input_allocate_device();
 	if (!w8001 || !input_dev_pen || !input_dev_touch) {

--- a/4.18/wacom_w8001.c
+++ b/4.18/wacom_w8001.c
@@ -596,7 +596,7 @@ static int w8001_connect(struct serio *serio, struct serio_driver *drv)
 	char basename[64] = "Wacom Serial";
 	int err, err_pen, err_touch;
 
-	w8001 = kzalloc(sizeof(*w8001), GFP_KERNEL);
+	w8001 = kzalloc_obj(*w8001, GFP_KERNEL);
 	input_dev_pen = input_allocate_device();
 	input_dev_touch = input_allocate_device();
 	if (!w8001 || !input_dev_pen || !input_dev_touch) {

--- a/4.18/wacom_w8001.c
+++ b/4.18/wacom_w8001.c
@@ -375,6 +375,7 @@ static int w8001_command(struct w8001 *w8001, unsigned char command,
 	return rc;
 }
 
+#ifdef WACOM_SCOPED_GUARD
 static int w8001_open(struct input_dev *dev)
 {
 	struct w8001 *w8001 = input_get_drvdata(dev);
@@ -393,15 +394,42 @@ static int w8001_open(struct input_dev *dev)
 
 	return -EINTR;
 }
+#else
+static int w8001_open(struct input_dev *dev)
+{
+	struct w8001 *w8001 = input_get_drvdata(dev);
+	int err;
+
+	err = mutex_lock_interruptible(&w8001->mutex);
+	if (err)
+		return err;
+
+	if (w8001->open_count++ == 0) {
+		err = w8001_command(w8001, W8001_CMD_START, false);
+		if (err)
+			w8001->open_count--;
+	}
+
+	mutex_unlock(&w8001->mutex);
+	return err;
+}
+#endif
 
 static void w8001_close(struct input_dev *dev)
 {
 	struct w8001 *w8001 = input_get_drvdata(dev);
-
+#ifdef WACOM_GUARD
 	guard(mutex)(&w8001->mutex);
+#else
+	mutex_lock(&w8001->mutex);
+#endif
 
 	if (--w8001->open_count == 0)
 		w8001_command(w8001, W8001_CMD_STOP, false);
+#ifdef WACOM_GUARD
+#else
+	mutex_unlock(&w8001->mutex);
+#endif
 }
 
 static int w8001_detect(struct w8001 *w8001)
@@ -596,7 +624,11 @@ static int w8001_connect(struct serio *serio, struct serio_driver *drv)
 	char basename[64] = "Wacom Serial";
 	int err, err_pen, err_touch;
 
+#ifdef WACOM_KZALLOC_OBJ
 	w8001 = kzalloc_obj(*w8001);
+#else
+	w8001 = kzalloc(sizeof(*w8001), GFP_KERNEL);
+#endif
 	input_dev_pen = input_allocate_device();
 	input_dev_touch = input_allocate_device();
 	if (!w8001 || !input_dev_pen || !input_dev_touch) {

--- a/4.18/wacom_wac.c
+++ b/4.18/wacom_wac.c
@@ -1208,8 +1208,11 @@ static int int_dist(int x1, int y1, int x2, int y2)
 static void wacom_intuos_bt_process_data(struct wacom_wac *wacom,
 		unsigned char *data)
 {
-	memcpy(wacom->data, data, 10);
+	u8 *saved_data = wacom->data;
+
+	wacom->data = data;
 	wacom_intuos_irq(wacom);
+	wacom->data = saved_data;
 
 	input_sync(wacom->pen_input);
 	if (wacom->pad_input)
@@ -1218,7 +1221,7 @@ static void wacom_intuos_bt_process_data(struct wacom_wac *wacom,
 
 static int wacom_intuos_bt_irq(struct wacom_wac *wacom, size_t len)
 {
-	u8 *data = kmemdup(wacom->data, len, GFP_KERNEL);
+	u8 *data = wacom->data;
 	int i = 1;
 	unsigned power_raw, battery_capacity, bat_charging, ps_connected;
 
@@ -1258,7 +1261,6 @@ static int wacom_intuos_bt_irq(struct wacom_wac *wacom, size_t len)
 		break;
 	}
 
-	kfree(data);
 	return 0;
 }
 

--- a/4.18/wacom_wac.h
+++ b/4.18/wacom_wac.h
@@ -322,6 +322,7 @@ struct wacom_shared {
 struct hid_data {
 	__s16 inputmode;	/* InputMode HID feature, -1 if non-existent */
 	__s16 inputmode_index;	/* InputMode HID feature index in the report */
+	__s16 inputmode_field_index; /* InputMode HID feature field index in the report */
 	bool sense_state;
 	bool inrange_state;
 	bool eraser;

--- a/configure.ac
+++ b/configure.ac
@@ -368,6 +368,23 @@ WACOM_LINUX_TRY_COMPILE([
 	AC_MSG_RESULT([no])
 ])
 
+dnl Check if kzalloc_obj exists
+AC_MSG_CHECKING(kzalloc_obj)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/slab.h>
+#ifndef kzalloc_obj
+#error "kzalloc_obj is not defined"
+#endif
+],[
+],[
+	HAVE_KZALLOC_OBJ=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_KZALLOC_OBJ], [], [kernel defines kzalloc_obj from v7.0])
+],[
+	HAVE_KZALLOC_OBJ=no
+	AC_MSG_RESULT([no])
+])
+
 dnl Check which version of the driver we should compile
 AC_DEFUN([WCM_EXPLODE], [$(echo "$1" | awk '{split($[0],x,"[[^0-9]]"); printf("%03d%03d%03d\n",x[[1]],x[[2]],x[[3]]);}')])
 EXPLODED_VER="WCM_EXPLODE($MODUTS)"

--- a/configure.ac
+++ b/configure.ac
@@ -385,6 +385,91 @@ WACOM_LINUX_TRY_COMPILE([
 	AC_MSG_RESULT([no])
 ])
 
+dnl Check if hid_warn_ratelimited exists
+AC_MSG_CHECKING(hid_warn_ratelimited)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/hid.h>
+#ifndef hid_warn_ratelimited
+#error "hid_warn_ratelimited is not defined"
+#endif
+],[
+],[
+	HAVE_HID_WARN_RATELIMITED=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_HID_WARN_RATELIMITED], [], [kernel defines hid_warn_ratelimited from v6.17])
+],[
+	HAVE_HID_WARN_RATELIMITED=no
+	AC_MSG_RESULT([no])
+])
+
+dnl Check if __free exists
+AC_MSG_CHECKING(__free)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/cleanup.h>
+#ifndef __free
+#error "__free is not defined"
+#endif
+],[
+],[
+	HAVE_CLEANUP_FREE=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_CLEANUP_FREE], [], [kernel defines __free from v6.5])
+],[
+	HAVE_CLEANUP_FREE=no
+	AC_MSG_RESULT([no])
+])
+
+dnl Check if scoped_guard exists
+AC_MSG_CHECKING(scoped_guard)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/cleanup.h>
+#ifndef scoped_guard
+#error "scoped_guard is not defined"
+#endif
+],[
+],[
+	HAVE_SCOPED_GUARD=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_SCOPED_GUARD], [], [kernel defines scoped_guard from v6.5])
+],[
+	HAVE_SCOPED_GUARD=no
+	AC_MSG_RESULT([no])
+])
+
+dnl Check if guard exists
+AC_MSG_CHECKING(guard)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/cleanup.h>
+#ifndef guard
+#error "guard is not defined"
+#endif
+],[
+],[
+	HAVE_GUARD=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_GUARD], [], [kernel defines guard from v6.5])
+],[
+	HAVE_GUARD=no
+	AC_MSG_RESULT([no])
+])
+
+dnl Check if define_simple_dev_pm_ops exists
+AC_MSG_CHECKING(define_simple_dev_pm_ops)
+WACOM_LINUX_TRY_COMPILE([
+#include <linux/pm.h>
+#ifndef DEFINE_SIMPLE_DEV_PM_OPS
+#error "define_simple_dev_pm_ops is not defined"
+#endif
+],[
+],[
+	HAVE_DEFINE_SIMPLE_DEV_PM_OPS=yes
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([WACOM_DEFINE_SIMPLE_DEV_PM_OPS], [], [kernel defines define_simple_dev_pm_ops from v5.17])
+],[
+	HAVE_DEFINE_SIMPLE_DEV_PM_OPS=no
+	AC_MSG_RESULT([no])
+])
+
 dnl Check which version of the driver we should compile
 AC_DEFUN([WCM_EXPLODE], [$(echo "$1" | awk '{split($[0],x,"[[^0-9]]"); printf("%03d%03d%03d\n",x[[1]],x[[2]],x[[3]]);}')])
 EXPLODED_VER="WCM_EXPLODE($MODUTS)"


### PR DESCRIPTION
Multiple Backports for the upcoming Input Wacom 1.7.0 release that touches on wacom_i2c, wacom_sys, and wacom_w8001.

These changes required 7 new definitions/flags in order to ensure older kernel version could compile.

WACOM_HID_REPORT_RAW_EVENT_BUFSIZE
WACOM_KZALLOC_OBJ
WACOM_HID_WARN_RATELIMITED
WACOM_CLEANUP_FREE
WACOM_SCOPED_GUARD
WACOM_GUARD
WACOM_DEFINE_SIMPLE_DEV_PM_OPS

I also added a few kernel versions to the testing workflow at the kernel versions these new definitions exist at to ensure they are being covered properly.